### PR TITLE
chore: devops fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -52,3 +52,17 @@ SpacesInCStyleCastParentheses: false
 SpacesInContainerLiterals: true
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
+
+# Import ordering
+SortIncludes: true
+IncludeBlocks: Regroup
+IncludeCategories:
+  # Main header (matching filename)
+  - Regex: '^"[^/]*\.h"$'
+    Priority: 1
+  # Local/Project headers
+  - Regex: '^"'
+    Priority: 2
+  # System headers with brackets
+  - Regex: "^<"
+    Priority: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Clone patcher
         uses: actions/checkout@v4
         with:
-          repository: unbound-mod/patcher-ios
+          repository: unbound-app/patcher-ios
           path: patcher-ios
 
       - name: Build and run patcher

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "resources"]
 	path = resources
-	url = https://github.com/unbound-mod/bootstrap
+	url = https://github.com/unbound-app/bootstrap

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ $(TWEAK_NAME)_FRAMEWORKS = UIKit Foundation UniformTypeIdentifiers
 
 BUNDLE_NAME = UnboundResources
 $(BUNDLE_NAME)_INSTALL_PATH = "/Library/Application\ Support/"
+$(BUNDLE_NAME)_RESOURCE_DIRS = "resources"
 
 include $(THEOS_MAKE_PATH)/tweak.mk
 include $(THEOS_MAKE_PATH)/bundle.mk

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TARGET := iphone:clang:latest:14.0
 include $(THEOS)/makefiles/common.mk
 
 TWEAK_NAME = Unbound
-$(TWEAK_NAME)_FILES = $(shell find sources -name "*.x*" -o -name "*.m")
+$(TWEAK_NAME)_FILES = $(shell find sources -name "*.x*" -o -name "*.m*")
 $(TWEAK_NAME)_CFLAGS =  -fobjc-arc -DPACKAGE_VERSION='@"$(THEOS_PACKAGE_BASE_VERSION)"' -DLOGS=$(LOGS) -I$(THEOS_PROJECT_DIR)/headers
 $(TWEAK_NAME)_FRAMEWORKS = UIKit Foundation UniformTypeIdentifiers
 
@@ -19,6 +19,11 @@ include $(THEOS_MAKE_PATH)/tweak.mk
 include $(THEOS_MAKE_PATH)/bundle.mk
 
 before-all::
+	@if [ ! -d "resources" ] || [ -z "$$(ls -A resources 2>/dev/null)" ]; then \
+		echo "Resources folder empty or missing, initializing submodule..."; \
+		git submodule update --init --recursive || exit 1; \
+	fi
+
 	$(ECHO_NOTHING)VERSION_NUM=$$(echo "$(THEOS_PACKAGE_BASE_VERSION)" | cut -d'.' -f1,2) && \
 		sed "s/VERSION_PLACEHOLDER/$$VERSION_NUM/" sources/preload.template.js > resources/preload.js$(ECHO_END)
 
@@ -27,4 +32,5 @@ after-stage::
 
 after-package::
 	$(ECHO_NOTHING)rm resources/preload.js$(ECHO_END)
+	
 

--- a/build-local.sh
+++ b/build-local.sh
@@ -56,7 +56,7 @@ print_success "Built tweak"
 
 print_status "Building patcher..."
 rm -rf patcher-ios
-git clone https://github.com/unbound-mod/patcher-ios
+git clone https://github.com/unbound-app/patcher-ios
 cd patcher-ios
 go build -o patcher
 cd ..

--- a/headers/Fonts.h
+++ b/headers/Fonts.h
@@ -1,9 +1,9 @@
+#import "Unbound.h"
+
 #include <CoreGraphics/CGFont.h>
 #include <CoreText/CoreText.h>
 #include <objc/runtime.h>
 #include <substrate.h>
-
-#import "Unbound.h"
 
 @interface Fonts : NSObject
 {

--- a/headers/Misc.h
+++ b/headers/Misc.h
@@ -1,1 +1,2 @@
 #import "Unbound.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>

--- a/headers/Recovery.h
+++ b/headers/Recovery.h
@@ -1,15 +1,15 @@
+#import "DeviceModels.h"
+#import "FileSystem.h"
+#import "Settings.h"
+#import "Updater.h"
+#import "Utilities.h"
+
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <objc/message.h>
 #import <spawn.h>
 #import <sys/utsname.h>
-
-#import "DeviceModels.h"
-#import "FileSystem.h"
-#import "Settings.h"
-#import "Updater.h"
-#import "Utilities.h"
 
 BOOL      isRecoveryModeEnabled(void);
 NSString *getDeviceIdentifier(void);

--- a/headers/Themes.h
+++ b/headers/Themes.h
@@ -1,4 +1,6 @@
 #import "Unbound.h"
+#import <objc/runtime.h>
+#import <substrate.h>
 
 @interface DCDTheme : NSObject
 + (NSInteger)themeIndex;

--- a/headers/Themes.h
+++ b/headers/Themes.h
@@ -1,4 +1,5 @@
 #import "Unbound.h"
+
 #import <objc/runtime.h>
 #import <substrate.h>
 

--- a/headers/Unbound.h
+++ b/headers/Unbound.h
@@ -1,6 +1,3 @@
-#include <Foundation/Foundation.h>
-#include <UIKit/UIKit.h>
-
 #import "FileSystem.h"
 #import "Fonts.h"
 #import "Plugins.h"
@@ -10,6 +7,9 @@
 #import "Utilities.h"
 
 #include "Discord/RCT.h"
+
+#include <Foundation/Foundation.h>
+#include <UIKit/UIKit.h>
 
 #ifdef DEBUG
 #define IS_DEBUG        true

--- a/headers/Utilities.h
+++ b/headers/Utilities.h
@@ -1,4 +1,7 @@
 #import "Unbound.h"
+#import <CommonCrypto/CommonCrypto.h>
+#import "FileSystem.h"
+#import <rootless.h>
 
 @interface Utilities : NSObject
 {

--- a/headers/Utilities.h
+++ b/headers/Utilities.h
@@ -1,6 +1,7 @@
-#import "Unbound.h"
-#import <CommonCrypto/CommonCrypto.h>
 #import "FileSystem.h"
+#import "Unbound.h"
+
+#import <CommonCrypto/CommonCrypto.h>
 #import <rootless.h>
 
 @interface Utilities : NSObject

--- a/sources/Misc.x
+++ b/sources/Misc.x
@@ -150,6 +150,7 @@
 %end
 %end
 
+#ifdef DEBUG
 %group Debug
 %hook  NSError
 - (id)initWithDomain:(id)domain code:(int)code userInfo:(id)userInfo
@@ -179,6 +180,7 @@
 };
 %end
 %end
+#endif
 
 %ctor
 {

--- a/sources/Misc.x
+++ b/sources/Misc.x
@@ -1,5 +1,4 @@
 #import "Misc.h"
-#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 %hook SentrySDK
 + (void)startWithOptions:(id)options

--- a/sources/Recovery.x
+++ b/sources/Recovery.x
@@ -402,7 +402,7 @@ BOOL isRecoveryModeEnabled(void)
                                      preferredStyle:UIAlertControllerStyleAlert];
     [self presentViewController:loadingAlert animated:YES completion:nil];
 
-    NSURL *url = [NSURL URLWithString:@"https://api.github.com/repos/unbound-mod/builds/branches"];
+    NSURL *url = [NSURL URLWithString:@"https://api.github.com/repos/unbound-app/builds/branches"];
     NSURLSession *session = [NSURLSession
         sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
 
@@ -490,7 +490,7 @@ BOOL isRecoveryModeEnabled(void)
 
     NSString *commitsUrl = [NSString
         stringWithFormat:
-            @"https://api.github.com/repos/unbound-mod/builds/commits?sha=%@&per_page=10", branch];
+            @"https://api.github.com/repos/unbound-app/builds/commits?sha=%@&per_page=10", branch];
     NSURL    *commitsURL = [NSURL URLWithString:commitsUrl];
 
     [[session
@@ -563,7 +563,7 @@ BOOL isRecoveryModeEnabled(void)
                                                                                    @"raw."
                                                                                    @"githubusercont"
                                                                                    @"ent.com/"
-                                                                                   @"unbound-mod/"
+                                                                                   @"unbound-app/"
                                                                                    @"builds/%@/"
                                                                                    @"unbound.js",
                                                                                    sha];
@@ -746,7 +746,7 @@ BOOL isRecoveryModeEnabled(void)
                                                                      URLQueryAllowedCharacterSet]];
 
     NSString *urlString = [NSString
-        stringWithFormat:@"https://github.com/unbound-mod/client/issues/new?title=%@&body=%@",
+        stringWithFormat:@"https://github.com/unbound-app/client/issues/new?title=%@&body=%@",
                          encodedTitle, encodedBody];
     NSURL    *url       = [NSURL URLWithString:urlString];
     [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];

--- a/sources/Themes.x
+++ b/sources/Themes.x
@@ -1,6 +1,4 @@
 #import "Themes.h"
-#import <objc/runtime.h>
-#import <substrate.h>
 
 @implementation Themes
 static NSMutableDictionary<NSString *, NSValue *> *originalRawImplementations;

--- a/sources/Updater.m
+++ b/sources/Updater.m
@@ -40,7 +40,7 @@ static NSString *etag = nil;
 {
     NSString *url = [Settings getString:@"unbound"
                                     key:@"loader.update.url"
-                                    def:@"https://raw.githubusercontent.com/unbound-mod/builds/"
+                                    def:@"https://raw.githubusercontent.com/unbound-app/builds/"
                                         @"refs/heads/main/unbound.js"];
 
     return [NSURL URLWithString:url];

--- a/sources/Utilities.m
+++ b/sources/Utilities.m
@@ -1,8 +1,4 @@
-#import <CommonCrypto/CommonCrypto.h>
-
-#import "FileSystem.h"
 #import "Utilities.h"
-#import <rootless.h>
 
 @implementation Utilities
 static NSString *bundle = nil;


### PR DESCRIPTION
this pr fixes a few things that were overlooked
- if the resources submodule is missing the pre-build step now initializes it so that it no longer builds a faulty resource bundle (this fixes #13)
- the debug hook group now gets defined conditionally which no longer causes a build failure when built for prod
- also adjusted the org name and objcpp file matching
- added import ordering to the clang-format config