### PR TITLE
feat: add share extension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ on:
         default: false
         description: "This is a TestFlight build"
         type: boolean
-      add_extension:
+      add_extensions:
         default: true
-        description: "Include OpenInDiscord"
+        description: "Include extensions (OpenInDiscord & ShareToDiscord)"
         type: boolean
   workflow_call:
     inputs:
@@ -32,7 +32,7 @@ on:
       is_testflight:
         default: false
         type: boolean
-      add_extension:
+      add_extensions:
         default: true
         type: boolean
       caller_workflow:
@@ -187,9 +187,18 @@ jobs:
           go build -o patcher
           ./patcher -i ../discord.ipa -o ../patched.ipa
 
-      - name: Build Safari Extension
-        if: inputs.add_extension == true
+      - name: Update ShareToDiscord Info.plist
+        if: inputs.add_extensions == true
         run: |
+          INFO_PLIST="extensions/ShareToDiscord/Share/Info.plist"
+          /usr/libexec/PlistBuddy -c "Set :URLScheme unbound" "$INFO_PLIST" 2>/dev/null || \
+          /usr/libexec/PlistBuddy -c "Add :URLScheme string unbound" "$INFO_PLIST"
+          echo "Updated ShareToDiscord Info.plist - Changed URLScheme to 'unbound'"
+
+      - name: Build Extensions
+        if: inputs.add_extensions == true
+        run: |
+          # Build OpenInDiscord Extension
           cd extensions/OpenInDiscord
           xcodebuild build \
             -target "OpenInDiscord Extension" \
@@ -205,6 +214,24 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             ONLY_ACTIVE_ARCH=NO | xcbeautify
+          
+          # Build ShareToDiscord Extension
+          cd ../ShareToDiscord
+          xcodebuild build \
+            -target "Share" \
+            -configuration Release \
+            -sdk iphoneos \
+            CONFIGURATION_BUILD_DIR="build" \
+            PRODUCT_NAME="Share" \
+            PRODUCT_BUNDLE_IDENTIFIER="com.hammerandchisel.discord.Share" \
+            PRODUCT_MODULE_NAME="Share" \
+            SKIP_INSTALL=NO \
+            DEVELOPMENT_TEAM="" \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            ONLY_ACTIVE_ARCH=NO | xcbeautify
+          cd ../../
 
       - name: Extract app name
         run: |
@@ -214,13 +241,13 @@ jobs:
       - name: Install cyan
         run: pip install --force-reinstall https://github.com/asdfzxcvbn/pyzule-rw/archive/main.zip Pillow
 
-      - name: Inject tweak (and extension)
+      - name: Inject tweak (and extensions)
         run: |
-          if [ ${{ inputs.add_extension }} == true ]; then
+          if [ ${{ inputs.add_extensions }} == true ]; then
             if [ ${{ inputs.is_testflight }} == true ]; then
-              cyan -duwsgq -b "com.hammerandchisel.discord.testflight" -i discord.ipa -o ${{ env.APP_NAME }}.ipa -f *.deb extensions/OpenInDiscord/build/OpenInDiscord.appex
+              cyan -duwsgq -b "com.hammerandchisel.discord.testflight" -i discord.ipa -o ${{ env.APP_NAME }}.ipa -f *.deb extensions/OpenInDiscord/build/OpenInDiscord.appex extensions/ShareToDiscord/build/Share.appex
             else
-              cyan -duwsgq -i patched.ipa -o ${{ env.APP_NAME }}.ipa -f *.deb extensions/OpenInDiscord/build/OpenInDiscord.appex
+              cyan -duwsgq -i patched.ipa -o ${{ env.APP_NAME }}.ipa -f *.deb extensions/OpenInDiscord/build/OpenInDiscord.appex extensions/ShareToDiscord/build/Share.appex
             fi
           else
             if [ ${{ inputs.is_testflight }} == true ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,14 @@ jobs:
       - name: Build Extensions
         if: inputs.add_extensions == true
         run: |
-          # Build OpenInDiscord Extension
+          if [ ${{ inputs.is_testflight }} == true ]; then
+            SAFARI_EXT_BUNDLE_ID="com.hammerandchisel.discord.testflight.OpenInDiscord"
+            SHARE_EXT_BUNDLE_ID="com.hammerandchisel.discord.testflight.Share"
+          else
+            SAFARI_EXT_BUNDLE_ID="com.hammerandchisel.discord.OpenInDiscord"
+            SHARE_EXT_BUNDLE_ID="com.hammerandchisel.discord.Share"
+          fi
+          
           cd extensions/OpenInDiscord
           xcodebuild build \
             -target "OpenInDiscord Extension" \
@@ -206,7 +213,7 @@ jobs:
             -sdk iphoneos \
             CONFIGURATION_BUILD_DIR="build" \
             PRODUCT_NAME="OpenInDiscord" \
-            PRODUCT_BUNDLE_IDENTIFIER="com.hammerandchisel.discord.OpenInDiscord" \
+            PRODUCT_BUNDLE_IDENTIFIER="$SAFARI_EXT_BUNDLE_ID" \
             PRODUCT_MODULE_NAME="OpenInDiscordExt" \
             SKIP_INSTALL=NO \
             DEVELOPMENT_TEAM="" \
@@ -215,7 +222,6 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             ONLY_ACTIVE_ARCH=NO | xcbeautify
           
-          # Build ShareToDiscord Extension
           cd ../ShareToDiscord
           xcodebuild build \
             -target "Share" \
@@ -223,7 +229,7 @@ jobs:
             -sdk iphoneos \
             CONFIGURATION_BUILD_DIR="build" \
             PRODUCT_NAME="Share" \
-            PRODUCT_BUNDLE_IDENTIFIER="com.hammerandchisel.discord.Share" \
+            PRODUCT_BUNDLE_IDENTIFIER="$SHARE_EXT_BUNDLE_ID" \
             PRODUCT_MODULE_NAME="Share" \
             SKIP_INSTALL=NO \
             DEVELOPMENT_TEAM="" \

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/castdrian/OpenInDiscord
 [submodule "extensions/ShareToDiscord"]
 	path = extensions/ShareToDiscord
-	url = https://github.com/castdrian/ShareToDiscord.git
+	url = https://github.com/castdrian/ShareToDiscord

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "extensions/OpenInDiscord"]
 	path = extensions/OpenInDiscord
 	url = https://github.com/castdrian/OpenInDiscord
+[submodule "extensions/ShareToDiscord"]
+	path = extensions/ShareToDiscord
+	url = https://github.com/castdrian/ShareToDiscord.git

--- a/build-local.sh
+++ b/build-local.sh
@@ -57,18 +57,18 @@ fi
 
 USE_EXTENSION=0
 if [ "$UNAME" = "Darwin" ]; then
-    print_status "Include Safari extension? (y/n):"
-    read -t 3 SAFARI_INPUT
+    print_status "Include extensions? (y/n):"
+    read -t 3 EXTENSIONS_INPUT
     if [ $? -gt 128 ]; then
         echo "y"
         USE_EXTENSION=1
-        print_status "Including Safari extension... (default)"
-    elif [[ $SAFARI_INPUT =~ ^[Nn]$ ]]; then
+        print_status "Including extensions... (default)"
+    elif [[ $EXTENSIONS_INPUT =~ ^[Nn]$ ]]; then
         USE_EXTENSION=0
-        print_status "Skipping Safari extension..."
+        print_status "Skipping extensions..."
     else
         USE_EXTENSION=1
-        print_status "Including Safari extension..."
+        print_status "Including extensions..."
     fi
 fi
 
@@ -147,8 +147,9 @@ if [ $? -ne 0 ]; then
 fi
 print_success "Patched ipa"
 
-SAFARI_EXT=""
+EXTENSIONS=""
 if [ "$USE_EXTENSION" = "1" ] && [ "$UNAME" = "Darwin" ]; then
+    # OpenInDiscord Extension
     SAFARI_EXT="extensions/OpenInDiscord/build/OpenInDiscord.appex"
     
     if [ ! -f "$SAFARI_EXT" ]; then
@@ -168,7 +169,7 @@ if [ "$USE_EXTENSION" = "1" ] && [ "$UNAME" = "Darwin" ]; then
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            ONLY_ACTIVE_ARCH=NO
+            ONLY_ACTIVE_ARCH=NO | xcbeautify
         cd ../..
 
         if [ $? -ne 0 ]; then
@@ -179,6 +180,53 @@ if [ "$USE_EXTENSION" = "1" ] && [ "$UNAME" = "Darwin" ]; then
     else
         print_status "Using existing Safari extension..."
     fi
+    
+    EXTENSIONS="$SAFARI_EXT"
+    
+    # ShareToDiscord Extension
+    SHARE_EXT="extensions/ShareToDiscord/build/Share.appex"
+    
+    # Update the Info.plist to change URLScheme from 'discord' to 'unbound'
+    print_status "Updating ShareToDiscord Info.plist..."
+    INFO_PLIST_PATH="extensions/ShareToDiscord/Share/Info.plist"
+    if [ -f "$INFO_PLIST_PATH" ]; then
+        /usr/libexec/PlistBuddy -c "Set :URLScheme unbound" "$INFO_PLIST_PATH" 2>/dev/null || \
+        /usr/libexec/PlistBuddy -c "Add :URLScheme string unbound" "$INFO_PLIST_PATH"
+        print_success "Updated ShareToDiscord Info.plist"
+    else
+        print_error "ShareToDiscord Info.plist not found at $INFO_PLIST_PATH"
+    fi
+    
+    if [ ! -f "$SHARE_EXT" ]; then
+        print_status "Building Share extension..."
+        mkdir -p extensions/ShareToDiscord/build
+        cd extensions/ShareToDiscord
+        xcodebuild build \
+            -target "Share" \
+            -configuration Release \
+            -sdk iphoneos \
+            CONFIGURATION_BUILD_DIR="build" \
+            PRODUCT_NAME="Share" \
+            PRODUCT_BUNDLE_IDENTIFIER="com.hammerandchisel.discord.Share" \
+            PRODUCT_MODULE_NAME="Share" \
+            SKIP_INSTALL=NO \
+            DEVELOPMENT_TEAM="" \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            ONLY_ACTIVE_ARCH=NO | xcbeautify
+        cd ../..
+
+        if [ $? -ne 0 ]; then
+            print_error "Failed to build Share extension"
+            exit 1
+        fi
+        print_success "Built Share extension"
+    else
+        print_status "Using existing Share extension..."
+    fi
+    
+    EXTENSIONS="$EXTENSIONS $SHARE_EXT"
 fi
 
 if [ ! -d "venv" ] || [ ! -f "venv/bin/cyan" ]; then
@@ -201,8 +249,8 @@ fi
 DEB_FILE=$(find packages -maxdepth 1 -name "*.deb" -print -quit)
 
 print_status "Injecting tweak..."
-if [ "$USE_EXTENSION" = "1" ] && [ -n "$SAFARI_EXT" ]; then
-    cyan -duwsgq -i "$TEMP_PATCHED_IPA" -o "$OUTPUT_IPA" -f "$DEB_FILE" "$SAFARI_EXT"
+if [ "$USE_EXTENSION" = "1" ] && [ -n "$EXTENSIONS" ]; then
+    cyan -duwsgq -i "$TEMP_PATCHED_IPA" -o "$OUTPUT_IPA" -f "$DEB_FILE" $EXTENSIONS
 else
     cyan -duwsgq -i "$TEMP_PATCHED_IPA" -o "$OUTPUT_IPA" -f "$DEB_FILE"
 fi

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Name: Unbound
 Description: Discord mobile client aimed at providing the user control, stability and customizability.
-Version: 1.3.0
+Version: 1.4.0
 Package: app.unbound.ios
 Architecture: iphoneos-arm
 Maintainer: eternal, acquitelol, Adrian Castro


### PR DESCRIPTION
this pr adds ShareToDiscord to the extension submodules and handles the building and bundling, the extension will pass along file urls to the main binary via a field that is configured in the extension info.plist

a relatively lazy example on how to handle received file urls from the react native portion is provided below:
```ts
import { Linking } from 'react-native';
import { createLogger } from '@structures/logger';

const Logger = createLogger('API', 'URLSchemes');

export function initialize() {
  Linking.getInitialURL().then(url => {
    if (url) {
      handleUrl(url);
    }
  }).catch(err => {
    Logger.error('Error getting initial URL:', err);
  });

  Linking.addEventListener('url', ({ url }) => {
    handleUrl(url);
  });
}

function handleUrl(url: string) {
  try {
    Logger.log('Handling URL:', url);

    if (url.startsWith('unbound://share')) {
      handleShareUrls(url);
      return;
    }
  } catch (error) {
    Logger.error('Error handling URL:', error);
  }
}

function handleShareUrls(urlString: string) {
  try {
    const url = new URL(urlString);
    const params = url.searchParams;
    const urls = params.getAll('url').filter(Boolean);

    if (urls.length === 0) {
      Logger.warn('No URLs found in share URL');
      return;
    }

    Logger.log('Processed share URLs:', urls);
  } catch (error) {
    Logger.error('Error handling share URL:', error);
  }
}

export default { initialize };
```