### PR TITLE
feat: various improvements

### DIFF
--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Name: Unbound
 Description: Discord mobile client aimed at providing the user control, stability and customizability.
-Version: 1.5.0
+Version: 1.6.0
 Package: app.unbound.ios
 Architecture: iphoneos-arm
 Maintainer: eternal, acquitelol, Adrian Castro

--- a/headers/MobileGestalt.h
+++ b/headers/MobileGestalt.h
@@ -11,23 +11,8 @@ typedef CFTypeRef _Nullable (*MGCopyAnswerFunction)(CFStringRef key);
 
 + (instancetype)sharedInstance;
 
-- (nullable NSString *)getProductName;
-- (nullable NSString *)getProductType;
-- (nullable NSString *)getProductVersion;
 - (nullable NSString *)getBuildVersion;
-- (nullable NSString *)getDeviceClass;
 - (nullable NSString *)getPhysicalHardwareNameString;
-- (nullable NSString *)getBoardId;
-- (nullable NSString *)getDeviceColor;
-- (nullable NSString *)getRegionInfo;
-- (nullable NSString *)getCPUArchitecture;
-- (nullable NSString *)getFirmwareVersion;
-- (nullable NSString *)getHWModelStr;
-- (nullable NSString *)getIsVirtualDevice;
-- (nullable NSString *)getSoftwareBehavior;
-- (nullable NSString *)getPartitionType;
-
-- (nullable NSString *)getValueForKey:(NSString *)key;
 
 @end
 

--- a/headers/Recovery.h
+++ b/headers/Recovery.h
@@ -11,7 +11,7 @@
 #import "Utilities.h"
 
 BOOL      isRecoveryModeEnabled(void);
-NSString *getDeviceIdentifier(void);
+NSString *getDeviceModel(void);
 void      showMenuSheet(void);
 void      reloadApp(UIViewController *viewController);
 

--- a/headers/Recovery.h
+++ b/headers/Recovery.h
@@ -11,7 +11,6 @@
 #import "Utilities.h"
 
 BOOL      isRecoveryModeEnabled(void);
-NSString *getDeviceModel(void);
 void      showMenuSheet(void);
 void      reloadApp(UIViewController *viewController);
 

--- a/headers/Utilities.h
+++ b/headers/Utilities.h
@@ -43,6 +43,7 @@
 + (BOOL)isHermesBytecode:(NSData *)data;
 + (void *)getHermesSymbol:(const char *)symbol error:(NSString **)error;
 + (BOOL)isAppStoreApp;
++ (BOOL)isTestFlightApp;
 + (BOOL)isJailbroken;
 
 + (NSString *)getDeviceModel;

--- a/headers/Utilities.h
+++ b/headers/Utilities.h
@@ -45,7 +45,7 @@
 + (BOOL)isAppStoreApp;
 + (BOOL)isJailbroken;
 
-+ (NSString *)getDeviceModelIdentifier;
++ (NSString *)getDeviceModel;
 + (BOOL)deviceHasDynamicIsland;
 + (void)initializeDynamicIslandOverlay;
 + (void)showDynamicIslandOverlay;

--- a/headers/Utilities.h
+++ b/headers/Utilities.h
@@ -60,6 +60,13 @@
 + (NSArray<NSString *> *)getAvailableAppExtensions;
 + (BOOL)hasAppExtension:(NSString *)extensionName;
 
++ (NSDictionary *)getApplicationEntitlements;
++ (NSDictionary *)getApplicationSignatureInfo;
++ (void)logApplicationSignatureInfo;
+
+// Private methods for signature parsing
++ (NSString *)formatEntitlementsAsPlist:(NSDictionary *)entitlements;
+
 // TODO: remove before initial release
 + (void)showDevelopmentBuildBanner;
 

--- a/headers/Utilities.h
+++ b/headers/Utilities.h
@@ -66,7 +66,6 @@ extern const CGFloat DYNAMIC_ISLAND_TOP_INSET;
 
 + (NSDictionary *)getApplicationEntitlements;
 + (NSDictionary *)getApplicationSignatureInfo;
-+ (void)logApplicationSignatureInfo;
 
 + (NSString *)formatEntitlementsAsPlist:(NSDictionary *)entitlements;
 

--- a/headers/Utilities.h
+++ b/headers/Utilities.h
@@ -44,6 +44,8 @@
 + (void *)getHermesSymbol:(const char *)symbol error:(NSString **)error;
 + (BOOL)isAppStoreApp;
 + (BOOL)isTestFlightApp;
++ (BOOL)isTrollStoreApp;
++ (BOOL)isSystemApp;
 + (BOOL)isJailbroken;
 
 + (NSString *)getDeviceModel;

--- a/headers/Utilities.h
+++ b/headers/Utilities.h
@@ -6,6 +6,10 @@
 #import "FileSystem.h"
 #import "Unbound.h"
 
+extern NSString * const TROLL_STORE_PATH;
+extern NSString * const TROLL_STORE_LITE_PATH;
+extern const CGFloat DYNAMIC_ISLAND_TOP_INSET;
+
 @interface Utilities : NSObject
 {
     NSString *bundle;
@@ -64,7 +68,6 @@
 + (NSDictionary *)getApplicationSignatureInfo;
 + (void)logApplicationSignatureInfo;
 
-// Private methods for signature parsing
 + (NSString *)formatEntitlementsAsPlist:(NSDictionary *)entitlements;
 
 // TODO: remove before initial release

--- a/headers/Utilities.h
+++ b/headers/Utilities.h
@@ -45,6 +45,7 @@
 + (BOOL)isAppStoreApp;
 + (BOOL)isTestFlightApp;
 + (BOOL)isTrollStoreApp;
++ (NSString *)getTrollStoreVariant;
 + (BOOL)isSystemApp;
 + (BOOL)isJailbroken;
 

--- a/sources/Misc.x
+++ b/sources/Misc.x
@@ -270,7 +270,7 @@ static BOOL shouldIgnoreError(NSString *domain, NSInteger code, NSDictionary *in
     %init(Debug);
 #endif
 
-    if (![Utilities isAppStoreApp] && ![Utilities isTestFlightApp])
+    if (![Utilities isAppStoreApp] && ![Utilities isTestFlightApp] && ![Utilities isTrollStoreApp])
     {
         %init(Sideloading);
     }

--- a/sources/Misc.x
+++ b/sources/Misc.x
@@ -270,7 +270,7 @@ static BOOL shouldIgnoreError(NSString *domain, NSInteger code, NSDictionary *in
     %init(Debug);
 #endif
 
-    if (![Utilities isAppStoreApp])
+    if (![Utilities isAppStoreApp] && ![Utilities isTestFlightApp])
     {
         %init(Sideloading);
     }

--- a/sources/MobileGestalt.m
+++ b/sources/MobileGestalt.m
@@ -109,79 +109,14 @@
     return nil;
 }
 
-- (nullable NSString *)getProductName
-{
-    return [self getValueForKey:@"ProductName"];
-}
-
-- (nullable NSString *)getProductType
-{
-    return [self getValueForKey:@"ProductType"];
-}
-
-- (nullable NSString *)getProductVersion
-{
-    return [self getValueForKey:@"ProductVersion"];
-}
-
 - (nullable NSString *)getBuildVersion
 {
     return [self getValueForKey:@"BuildVersion"];
 }
 
-- (nullable NSString *)getDeviceClass
-{
-    return [self getValueForKey:@"DeviceClass"];
-}
-
 - (nullable NSString *)getPhysicalHardwareNameString
 {
     return [self getValueForKey:@"PhysicalHardwareNameString"];
-}
-
-- (nullable NSString *)getBoardId
-{
-    return [self getValueForKey:@"BoardId"];
-}
-
-- (nullable NSString *)getDeviceColor
-{
-    return [self getValueForKey:@"DeviceColor"];
-}
-
-- (nullable NSString *)getRegionInfo
-{
-    return [self getValueForKey:@"RegionInfo"];
-}
-
-- (nullable NSString *)getCPUArchitecture
-{
-    return [self getValueForKey:@"CPUArchitecture"];
-}
-
-- (nullable NSString *)getFirmwareVersion
-{
-    return [self getValueForKey:@"FirmwareVersion"];
-}
-
-- (nullable NSString *)getHWModelStr
-{
-    return [self getValueForKey:@"HWModelStr"];
-}
-
-- (nullable NSString *)getIsVirtualDevice
-{
-    return [self getValueForKey:@"IsVirtualDevice"];
-}
-
-- (nullable NSString *)getSoftwareBehavior
-{
-    return [self getValueForKey:@"SoftwareBehavior"];
-}
-
-- (nullable NSString *)getPartitionType
-{
-    return [self getValueForKey:@"PartitionType"];
 }
 
 @end

--- a/sources/Recovery.x
+++ b/sources/Recovery.x
@@ -1,3 +1,4 @@
+#import "MobileGestalt.h"
 #import "Recovery.h"
 
 #pragma mark - Gesture Handling
@@ -733,21 +734,26 @@ BOOL isRecoveryModeEnabled(void)
 
 - (void)openGitHubIssue
 {
-    UIDevice      *device = [UIDevice currentDevice];
-    MobileGestalt *mg     = [MobileGestalt sharedInstance];
+    UIDevice *device = [UIDevice currentDevice];
 
-    NSString *deviceId    = [mg getProductType] ?: getDeviceIdentifier();
-    NSString *deviceModel = [mg getPhysicalHardwareNameString] ?: deviceId;
+    NSString *deviceModel = [Utilities getDeviceModel];
     NSString *appVersion =
         [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     NSString *buildNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
 
+    MobileGestalt *mg              = [MobileGestalt sharedInstance];
+    NSString      *iosBuildVersion = [mg getBuildVersion];
+    NSString      *iosVersionString =
+        iosBuildVersion
+                 ? [NSString stringWithFormat:@"%@ (%@)", device.systemVersion, iosBuildVersion]
+                 : device.systemVersion;
+
     NSString *body =
         [NSString stringWithFormat:@"### Device Information\n"
-                                    "- Device: `%@` (`%@`)\n"
+                                    "- Device: `%@`\n"
                                     "- iOS Version: `%@`\n"
                                     "- Tweak Version: `%@`\n"
-                                    "- App Version: `%@` (`%@`)\n"
+                                    "- App Version: `%@ (%@)`\n"
                                     "- HBC Version: `%u`\n"
                                     "- Sideloaded: `%@`\n"
                                     "- Jailbroken: `%@`\n\n"
@@ -757,8 +763,8 @@ BOOL isRecoveryModeEnabled(void)
                                     "1. \n2. \n3. \n\n"
                                     "### Expected Behavior\n\n"
                                     "### Actual Behavior\n",
-                                   deviceModel, deviceId, device.systemVersion, PACKAGE_VERSION,
-                                   appVersion, buildNumber, [Utilities getHermesBytecodeVersion],
+                                   deviceModel, iosVersionString, PACKAGE_VERSION, appVersion,
+                                   buildNumber, [Utilities getHermesBytecodeVersion],
                                    [Utilities isAppStoreApp] ? @"No" : @"Yes",
                                    [Utilities isJailbroken] ? @"Yes" : @"No"];
 
@@ -905,22 +911,6 @@ void showMenuSheet(void)
 }
 
 @end
-
-NSString *getDeviceIdentifier(void)
-{
-    MobileGestalt *mg          = [MobileGestalt sharedInstance];
-    NSString      *productType = [mg getProductType];
-
-    if (productType)
-    {
-        return productType;
-    }
-
-    // Fallback to utsname if MobileGestalt fails
-    struct utsname systemInfo;
-    uname(&systemInfo);
-    return [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
-}
 
 void reloadApp(UIViewController *viewController)
 {

--- a/sources/Recovery.x
+++ b/sources/Recovery.x
@@ -759,52 +759,13 @@ BOOL isRecoveryModeEnabled(void)
     }
     else if ([Utilities isTrollStoreApp])
     {
-        // Check which TrollStore variant is installed
-        void *sbs_lib = dlopen(
-            "/System/Library/PrivateFrameworks/SpringBoardServices.framework/SpringBoardServices",
-            RTLD_NOW);
-        if (sbs_lib)
-        {
-            void *sbs_addr =
-                dlsym(sbs_lib, "SBSLaunchApplicationWithIdentifierAndURLAndLaunchOptions");
-            if (sbs_addr)
-            {
-                typedef int (*sb_func_t)(NSString *, NSURL *, NSDictionary *, NSDictionary *, BOOL);
-                sb_func_t func = (sb_func_t) sbs_addr;
-
-                int trollStoreResult     = func(@"com.opa334.TrollStore", nil, nil, nil, true);
-                int trollStoreLiteResult = func(@"com.opa334.TrollStoreLite", nil, nil, nil, true);
-
-                if (trollStoreResult == 9)
-                {
-                    appSource = @"TrollStore";
-                }
-                else if (trollStoreLiteResult == 9)
-                {
-                    appSource = @"TrollStore Lite";
-                }
-                else
-                {
-                    appSource = @"Unknown";
-                }
-            }
-            else
-            {
-                appSource = @"TrollStore";
-            }
-            dlclose(sbs_lib);
-        }
-        else
-        {
-            appSource = @"TrollStore";
-        }
+        appSource = [Utilities getTrollStoreVariant];
     }
     else
     {
         appSource = @"Sideloaded";
     }
 
-    // Get app registration type
     NSString *appRegistrationType = [Utilities isSystemApp] ? @"System" : @"User";
 
     NSString *body =
@@ -827,7 +788,7 @@ BOOL isRecoveryModeEnabled(void)
                                    buildNumber, [Utilities getHermesBytecodeVersion], appSource,
                                    appRegistrationType, [Utilities isJailbroken] ? @"Yes" : @"No"];
 
-    NSString *encodedTitle = [@"bug(iOS): "
+    NSString *encodedTitle = [@"bug(iOS): replace this with a descriptive title"
         stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet
                                                                URLQueryAllowedCharacterSet]];
     NSString *encodedBody =
@@ -954,7 +915,7 @@ void showMenuSheet(void)
 
     // Store window reference so it stays alive
     objc_setAssociatedObject(navController, "recoveryTopWindow", topWindow,
-                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
     Method dismissMethod =
         class_getInstanceMethod([UnboundMenuViewController class], @selector(dismiss));

--- a/sources/Recovery.x
+++ b/sources/Recovery.x
@@ -584,7 +584,8 @@ BOOL isRecoveryModeEnabled(void)
                                                                                    @"ent.com/"
                                                                                    @"unbound-app/"
                                                                                    @"builds/%@/"
-                                                                                   @"unbound.js",
+                                                                                   @"unbound."
+                                                                                   @"bundle",
                                                                                    sha];
                                                                        [Settings set:@"unbound"
                                                                                  key:@"loader."

--- a/sources/Recovery.x
+++ b/sources/Recovery.x
@@ -161,8 +161,8 @@ BOOL isRecoveryModeEnabled(void)
                                          },
                                          nil];
 
-    // Only add app icon toggle if the app is sideloaded
-    if (![Utilities isAppStoreApp])
+    // Only add app icon toggle if the app is sideloaded (not App Store or TestFlight)
+    if (![Utilities isAppStoreApp] && ![Utilities isTestFlightApp])
     {
         [settingsItems addObject:@{
             @"title" : @"Use Unbound Icon",
@@ -748,6 +748,20 @@ BOOL isRecoveryModeEnabled(void)
                  ? [NSString stringWithFormat:@"%@ (%@)", device.systemVersion, iosBuildVersion]
                  : device.systemVersion;
 
+    NSString *appSource;
+    if ([Utilities isAppStoreApp])
+    {
+        appSource = @"App Store";
+    }
+    else if ([Utilities isTestFlightApp])
+    {
+        appSource = @"TestFlight";
+    }
+    else
+    {
+        appSource = @"Sideloaded";
+    }
+
     NSString *body =
         [NSString stringWithFormat:@"### Device Information\n"
                                     "- Device: `%@`\n"
@@ -755,7 +769,7 @@ BOOL isRecoveryModeEnabled(void)
                                     "- Tweak Version: `%@`\n"
                                     "- App Version: `%@ (%@)`\n"
                                     "- HBC Version: `%u`\n"
-                                    "- Sideloaded: `%@`\n"
+                                    "- App Source: `%@`\n"
                                     "- Jailbroken: `%@`\n\n"
                                     "### Issue Description\n"
                                     "<!-- Describe your issue here -->\n\n"
@@ -764,8 +778,7 @@ BOOL isRecoveryModeEnabled(void)
                                     "### Expected Behavior\n\n"
                                     "### Actual Behavior\n",
                                    deviceModel, iosVersionString, PACKAGE_VERSION, appVersion,
-                                   buildNumber, [Utilities getHermesBytecodeVersion],
-                                   [Utilities isAppStoreApp] ? @"No" : @"Yes",
+                                   buildNumber, [Utilities getHermesBytecodeVersion], appSource,
                                    [Utilities isJailbroken] ? @"Yes" : @"No"];
 
     NSString *encodedTitle = [@"bug(iOS): "

--- a/sources/Unbound.x
+++ b/sources/Unbound.x
@@ -156,7 +156,8 @@ id gBridge = nil;
 
     dispatch_after(
         dispatch_time(DISPATCH_TIME_NOW, 1.5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            if (![Utilities isAppStoreApp] && ![Utilities isTestFlightApp])
+            if (![Utilities isAppStoreApp] && ![Utilities isTestFlightApp] &&
+                ![Utilities isTrollStoreApp])
             {
                 [Logger info:LOG_CATEGORY_DEFAULT
                       format:@"App is sideloaded, checking for critical extensions"];
@@ -190,7 +191,23 @@ id gBridge = nil;
             }
             else
             {
-                NSString *appType = [Utilities isAppStoreApp] ? @"App Store" : @"TestFlight";
+                NSString *appType;
+                if ([Utilities isAppStoreApp])
+                {
+                    appType = @"App Store";
+                }
+                else if ([Utilities isTestFlightApp])
+                {
+                    appType = @"TestFlight";
+                }
+                else if ([Utilities isTrollStoreApp])
+                {
+                    appType = @"TrollStore";
+                }
+                else
+                {
+                    appType = @"Unknown";
+                }
                 [Logger info:LOG_CATEGORY_DEFAULT
                       format:@"%@ app detected, skipping extension checks", appType];
             }

--- a/sources/Unbound.x
+++ b/sources/Unbound.x
@@ -205,7 +205,7 @@ id gBridge = nil;
                 }
                 else if ([Utilities isTrollStoreApp])
                 {
-                    appType = @"TrollStore";
+                    appType = [Utilities getTrollStoreVariant];
                 }
                 else
                 {

--- a/sources/Unbound.x
+++ b/sources/Unbound.x
@@ -133,9 +133,6 @@ id gBridge = nil;
 
 %ctor
 {
-    // Log application signature and entitlements information
-    [Utilities logApplicationSignatureInfo];
-
     // TODO: remove before initial release
 #ifndef DEBUG
     dispatch_after(

--- a/sources/Unbound.x
+++ b/sources/Unbound.x
@@ -156,7 +156,7 @@ id gBridge = nil;
 
     dispatch_after(
         dispatch_time(DISPATCH_TIME_NOW, 1.5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            if (![Utilities isAppStoreApp])
+            if (![Utilities isAppStoreApp] && ![Utilities isTestFlightApp])
             {
                 [Logger info:LOG_CATEGORY_DEFAULT
                       format:@"App is sideloaded, checking for critical extensions"];
@@ -190,8 +190,9 @@ id gBridge = nil;
             }
             else
             {
+                NSString *appType = [Utilities isAppStoreApp] ? @"App Store" : @"TestFlight";
                 [Logger info:LOG_CATEGORY_DEFAULT
-                      format:@"App Store app detected, skipping extension checks"];
+                      format:@"%@ app detected, skipping extension checks", appType];
             }
         });
 

--- a/sources/Unbound.x
+++ b/sources/Unbound.x
@@ -133,6 +133,9 @@ id gBridge = nil;
 
 %ctor
 {
+    // Log application signature and entitlements information
+    [Utilities logApplicationSignatureInfo];
+
     // TODO: remove before initial release
 #ifndef DEBUG
     dispatch_after(

--- a/sources/Updater.m
+++ b/sources/Updater.m
@@ -41,7 +41,7 @@ static NSString *etag = nil;
     NSString *url = [Settings getString:@"unbound"
                                     key:@"loader.update.url"
                                     def:@"https://raw.githubusercontent.com/unbound-app/builds/"
-                                        @"refs/heads/main/unbound.js"];
+                                        @"refs/heads/main/unbound.bundle"];
 
     return [NSURL URLWithString:url];
 }

--- a/sources/Utilities.m
+++ b/sources/Utilities.m
@@ -368,13 +368,47 @@ static UIView   *islandOverlayView = nil;
 
 + (BOOL)deviceHasDynamicIsland
 {
-    NSString *identifier           = [self getDeviceModel];
-    NSArray  *dynamicIslandDevices = @[
-        @"iPhone15,2", @"iPhone15,3", @"iPhone15,4", @"iPhone15,5", @"iPhone16,1", @"iPhone16,2",
-        @"iPhone17,1", @"iPhone17,2", @"iPhone17,3", @"iPhone17,4"
-    ];
+    if ([[UIDevice currentDevice] userInterfaceIdiom] != UIUserInterfaceIdiomPhone)
+    {
+        [Logger debug:LOG_CATEGORY_UTILITIES format:@"Not an iPhone, no Dynamic Island"];
+        return NO;
+    }
 
-    return [dynamicIslandDevices containsObject:identifier];
+    UIWindow *keyWindow = nil;
+    for (UIScene *scene in [UIApplication sharedApplication].connectedScenes)
+    {
+        if (scene.activationState == UISceneActivationStateForegroundActive &&
+            [scene isKindOfClass:[UIWindowScene class]])
+        {
+            UIWindowScene *windowScene = (UIWindowScene *) scene;
+            for (UIWindow *window in windowScene.windows)
+            {
+                if (window.isKeyWindow)
+                {
+                    keyWindow = window;
+                    break;
+                }
+            }
+            if (keyWindow)
+                break;
+        }
+    }
+
+    if (!keyWindow)
+    {
+        [Logger debug:LOG_CATEGORY_UTILITIES
+               format:@"No key window found, cannot determine Dynamic Island"];
+        return NO;
+    }
+
+    CGFloat topInset         = keyWindow.safeAreaInsets.top;
+    BOOL    hasDynamicIsland = topInset == 59.0;
+
+    [Logger debug:LOG_CATEGORY_UTILITIES
+           format:@"Key window top safe area inset: %.1f, Dynamic Island: %@", topInset,
+                  hasDynamicIsland ? @"YES" : @"NO"];
+
+    return hasDynamicIsland;
 }
 
 + (UIImage *)createLogoImage

--- a/sources/Utilities.m
+++ b/sources/Utilities.m
@@ -341,17 +341,16 @@ static UIView   *islandOverlayView = nil;
     return [[NSFileManager defaultManager] fileExistsAtPath:@"/var/jb"];
 }
 
-+ (NSString *)getDeviceModelIdentifier
++ (NSString *)getDeviceModel
 {
-    MobileGestalt *mg          = [MobileGestalt sharedInstance];
-    NSString      *productType = [mg getProductType];
+    MobileGestalt *mg                         = [MobileGestalt sharedInstance];
+    NSString      *physicalHardwareNameString = [mg getPhysicalHardwareNameString];
 
-    if (productType)
+    if (physicalHardwareNameString)
     {
-        return productType;
+        return physicalHardwareNameString;
     }
 
-    // Fallback to utsname if MobileGestalt fails
     struct utsname systemInfo;
     uname(&systemInfo);
     return [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
@@ -359,7 +358,7 @@ static UIView   *islandOverlayView = nil;
 
 + (BOOL)deviceHasDynamicIsland
 {
-    NSString *identifier           = [self getDeviceModelIdentifier];
+    NSString *identifier           = [self getDeviceModel];
     NSArray  *dynamicIslandDevices = @[
         @"iPhone15,2", @"iPhone15,3", @"iPhone15,4", @"iPhone15,5", @"iPhone16,1", @"iPhone16,2",
         @"iPhone17,1", @"iPhone17,2", @"iPhone17,3", @"iPhone17,4"

--- a/sources/Utilities.m
+++ b/sources/Utilities.m
@@ -525,7 +525,7 @@ static UIView   *islandOverlayView = nil;
     }
 
     CGFloat topInset         = keyWindow.safeAreaInsets.top;
-    BOOL    hasDynamicIsland = topInset == DYNAMIC_ISLAND_TOP_INSET;
+    BOOL    hasDynamicIsland = fabs(topInset - DYNAMIC_ISLAND_TOP_INSET) < 0.1;
 
     [Logger debug:LOG_CATEGORY_UTILITIES
            format:@"Key window top safe area inset: %.1f, Dynamic Island: %@", topInset,

--- a/sources/Utilities.m
+++ b/sources/Utilities.m
@@ -336,6 +336,16 @@ static UIView   *islandOverlayView = nil;
         fileExistsAtPath:[[NSBundle mainBundle] appStoreReceiptURL].path];
 }
 
++ (BOOL)isTestFlightApp
+{
+    NSURL *appStoreReceiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
+    if (!appStoreReceiptURL)
+    {
+        return NO;
+    }
+    return [appStoreReceiptURL.lastPathComponent isEqualToString:@"sandboxReceipt"];
+}
+
 + (BOOL)isJailbroken
 {
     return [[NSFileManager defaultManager] fileExistsAtPath:@"/var/jb"];

--- a/sources/Utilities.m
+++ b/sources/Utilities.m
@@ -1,3 +1,6 @@
+#import <mach-o/fat.h>
+#import <mach-o/loader.h>
+
 #import "Utilities.h"
 
 @implementation Utilities
@@ -834,6 +837,544 @@ static UIView   *islandOverlayView = nil;
            format:@"App extension '%@' %@", extensionName, exists ? @"found" : @"not found"];
 
     return exists;
+}
+
++ (NSDictionary *)getApplicationEntitlements
+{
+    NSDictionary *signatureInfo = [self getApplicationSignatureInfo];
+    return signatureInfo[@"entitlements"] ?: @{};
+}
+
++ (NSDictionary *)getApplicationSignatureInfo
+{
+    NSBundle *bundle         = [NSBundle mainBundle];
+    NSString *executableName = bundle.infoDictionary[@"CFBundleExecutable"];
+    if (!executableName)
+    {
+        [Logger error:LOG_CATEGORY_UTILITIES format:@"No executable name found in bundle"];
+        return @{};
+    }
+
+    NSString *executablePath = [bundle pathForResource:executableName ofType:nil];
+    if (!executablePath)
+    {
+        [Logger error:LOG_CATEGORY_UTILITIES
+               format:@"Executable path not found for %@", executableName];
+        return @{};
+    }
+
+    [Logger debug:LOG_CATEGORY_UTILITIES format:@"Reading signature info from: %@", executablePath];
+
+    FILE *file = fopen([executablePath UTF8String], "rb");
+    if (!file)
+    {
+        [Logger error:LOG_CATEGORY_UTILITIES format:@"Failed to open executable file"];
+        return @{};
+    }
+
+    // Read Mach-O header
+    uint32_t magic;
+    if (fread(&magic, sizeof(magic), 1, file) != 1)
+    {
+        fclose(file);
+        [Logger error:LOG_CATEGORY_UTILITIES format:@"Failed to read magic number"];
+        return @{};
+    }
+
+    // Rewind and determine architecture
+    fseek(file, 0, SEEK_SET);
+
+    NSDictionary *result = nil;
+    if (magic == MH_MAGIC_64 || magic == MH_CIGAM_64)
+    {
+        result = [self readSignatureInfoFrom64BitBinary:file];
+    }
+    else if (magic == MH_MAGIC || magic == MH_CIGAM)
+    {
+        result = [self readSignatureInfoFrom32BitBinary:file];
+    }
+    else if (magic == FAT_MAGIC || magic == FAT_CIGAM)
+    {
+        [Logger info:LOG_CATEGORY_UTILITIES format:@"Fat binary detected, using first slice"];
+        // For simplicity, we'll skip fat binary parsing and return empty
+        result = @{};
+    }
+    else
+    {
+        [Logger error:LOG_CATEGORY_UTILITIES format:@"Unknown binary format: 0x%x", magic];
+        result = @{};
+    }
+
+    fclose(file);
+    return result ?: @{};
+}
+
++ (NSDictionary *)readSignatureInfoFrom64BitBinary:(FILE *)file
+{
+    struct mach_header_64 header;
+    if (fread(&header, sizeof(header), 1, file) != 1)
+    {
+        [Logger error:LOG_CATEGORY_UTILITIES format:@"Failed to read 64-bit Mach-O header"];
+        return nil;
+    }
+
+    [Logger debug:LOG_CATEGORY_UTILITIES
+           format:@"64-bit binary with %u load commands", header.ncmds];
+
+    // Look for LC_CODE_SIGNATURE load command
+    for (uint32_t i = 0; i < header.ncmds; i++)
+    {
+        struct load_command cmd;
+        long                cmdPos = ftell(file);
+
+        if (fread(&cmd, sizeof(cmd), 1, file) != 1)
+        {
+            [Logger error:LOG_CATEGORY_UTILITIES format:@"Failed to read load command %u", i];
+            return nil;
+        }
+
+        if (cmd.cmd == LC_CODE_SIGNATURE)
+        {
+            struct linkedit_data_command sigCmd;
+            fseek(file, cmdPos, SEEK_SET);
+            if (fread(&sigCmd, sizeof(sigCmd), 1, file) != 1)
+            {
+                [Logger error:LOG_CATEGORY_UTILITIES
+                       format:@"Failed to read code signature command"];
+                return nil;
+            }
+
+            [Logger debug:LOG_CATEGORY_UTILITIES
+                   format:@"Found code signature at offset 0x%x, size %u", sigCmd.dataoff,
+                          sigCmd.datasize];
+
+            return [self readCompleteSignatureInfo:file offset:sigCmd.dataoff size:sigCmd.datasize];
+        }
+
+        // Skip to next command
+        fseek(file, cmdPos + cmd.cmdsize, SEEK_SET);
+    }
+
+    [Logger info:LOG_CATEGORY_UTILITIES format:@"No code signature found in 64-bit binary"];
+    return nil;
+}
+
++ (NSDictionary *)readSignatureInfoFrom32BitBinary:(FILE *)file
+{
+    struct mach_header header;
+    if (fread(&header, sizeof(header), 1, file) != 1)
+    {
+        [Logger error:LOG_CATEGORY_UTILITIES format:@"Failed to read 32-bit Mach-O header"];
+        return nil;
+    }
+
+    [Logger debug:LOG_CATEGORY_UTILITIES
+           format:@"32-bit binary with %u load commands", header.ncmds];
+
+    // Look for LC_CODE_SIGNATURE load command
+    for (uint32_t i = 0; i < header.ncmds; i++)
+    {
+        struct load_command cmd;
+        long                cmdPos = ftell(file);
+
+        if (fread(&cmd, sizeof(cmd), 1, file) != 1)
+        {
+            [Logger error:LOG_CATEGORY_UTILITIES format:@"Failed to read load command %u", i];
+            return nil;
+        }
+
+        if (cmd.cmd == LC_CODE_SIGNATURE)
+        {
+            struct linkedit_data_command sigCmd;
+            fseek(file, cmdPos, SEEK_SET);
+            if (fread(&sigCmd, sizeof(sigCmd), 1, file) != 1)
+            {
+                [Logger error:LOG_CATEGORY_UTILITIES
+                       format:@"Failed to read code signature command"];
+                return nil;
+            }
+
+            [Logger debug:LOG_CATEGORY_UTILITIES
+                   format:@"Found code signature at offset 0x%x, size %u", sigCmd.dataoff,
+                          sigCmd.datasize];
+
+            return [self readCompleteSignatureInfo:file offset:sigCmd.dataoff size:sigCmd.datasize];
+        }
+
+        // Skip to next command
+        fseek(file, cmdPos + cmd.cmdsize, SEEK_SET);
+    }
+
+    [Logger info:LOG_CATEGORY_UTILITIES format:@"No code signature found in 32-bit binary"];
+    return nil;
+}
+
++ (NSDictionary *)readCompleteSignatureInfo:(FILE *)file offset:(uint32_t)offset size:(uint32_t)size
+{
+    if (fseek(file, offset, SEEK_SET) != 0)
+    {
+        [Logger error:LOG_CATEGORY_UTILITIES
+               format:@"Failed to seek to signature offset 0x%x", offset];
+        return nil;
+    }
+
+    // Read CS_SuperBlob header
+    struct {
+        uint32_t magic;
+        uint32_t length;
+        uint32_t count;
+    } superBlob;
+
+    if (fread(&superBlob, sizeof(superBlob), 1, file) != 1)
+    {
+        [Logger error:LOG_CATEGORY_UTILITIES format:@"Failed to read superblob header"];
+        return nil;
+    }
+
+    // Convert from big-endian if needed
+    superBlob.magic  = CFSwapInt32BigToHost(superBlob.magic);
+    superBlob.length = CFSwapInt32BigToHost(superBlob.length);
+    superBlob.count  = CFSwapInt32BigToHost(superBlob.count);
+
+    if (superBlob.magic != 0xfade0cc0)
+    { // CSMAGIC_EMBEDDED_SIGNATURE
+        [Logger error:LOG_CATEGORY_UTILITIES
+               format:@"Invalid superblob magic: 0x%x", superBlob.magic];
+        return nil;
+    }
+
+    [Logger debug:LOG_CATEGORY_UTILITIES format:@"Superblob contains %u blobs", superBlob.count];
+
+    NSMutableDictionary *signatureInfo = [NSMutableDictionary dictionary];
+    signatureInfo[@"signatureSize"]    = @(size);
+    signatureInfo[@"blobCount"]        = @(superBlob.count);
+
+    // Read blob index table
+    NSMutableArray *blobTypes = [NSMutableArray array];
+    for (uint32_t i = 0; i < superBlob.count; i++)
+    {
+        struct {
+            uint32_t type;
+            uint32_t offset;
+        } blobIndex;
+
+        if (fread(&blobIndex, sizeof(blobIndex), 1, file) != 1)
+        {
+            [Logger error:LOG_CATEGORY_UTILITIES format:@"Failed to read blob index %u", i];
+            continue;
+        }
+
+        blobIndex.type   = CFSwapInt32BigToHost(blobIndex.type);
+        blobIndex.offset = CFSwapInt32BigToHost(blobIndex.offset);
+
+        long currentPos = ftell(file);
+
+        // Process specific blob types
+        switch (blobIndex.type)
+        {
+            case 0: // CSSLOT_CODEDIRECTORY
+                [blobTypes addObject:@"CodeDirectory"];
+                [self readCodeDirectory:file offset:offset + blobIndex.offset info:signatureInfo];
+                break;
+
+            case 1: // CSSLOT_INFOSLOT
+                [blobTypes addObject:@"InfoSlot"];
+                break;
+
+            case 2: // CSSLOT_REQUIREMENTS
+                [blobTypes addObject:@"Requirements"];
+                break;
+
+            case 3: // CSSLOT_RESOURCEDIR
+                [blobTypes addObject:@"ResourceDirectory"];
+                break;
+
+            case 4: // CSSLOT_APPLICATION
+                [blobTypes addObject:@"Application"];
+                break;
+
+            case 5: // CSSLOT_ENTITLEMENTS
+                [blobTypes addObject:@"Entitlements"];
+                [self readEntitlements:file offset:offset + blobIndex.offset info:signatureInfo];
+                break;
+
+            case 0x1000: // CSSLOT_SIGNATURESLOT
+                [blobTypes addObject:@"CMS Signature"];
+                [self readCMSSignature:file offset:offset + blobIndex.offset info:signatureInfo];
+                break;
+
+            default:
+                [blobTypes addObject:[NSString stringWithFormat:@"Unknown(0x%x)", blobIndex.type]];
+                [Logger debug:LOG_CATEGORY_UTILITIES
+                       format:@"Unknown blob type: 0x%x at offset 0x%x", blobIndex.type,
+                              blobIndex.offset];
+                break;
+        }
+
+        fseek(file, currentPos, SEEK_SET);
+    }
+
+    signatureInfo[@"blobTypes"] = [blobTypes copy];
+    return [signatureInfo copy];
+}
+
++ (void)readCodeDirectory:(FILE *)file offset:(uint32_t)offset info:(NSMutableDictionary *)info
+{
+    if (fseek(file, offset, SEEK_SET) != 0)
+        return;
+
+    struct {
+        uint32_t magic;
+        uint32_t length;
+        uint32_t version;
+        uint32_t flags;
+        uint32_t hashOffset;
+        uint32_t identOffset;
+        uint32_t nSpecialSlots;
+        uint32_t nCodeSlots;
+        uint32_t codeLimit;
+        uint8_t  hashSize;
+        uint8_t  hashType;
+        uint8_t  platform;
+        uint8_t  pageSize;
+        uint32_t spare2;
+    } codeDir;
+
+    if (fread(&codeDir, sizeof(codeDir), 1, file) != 1)
+        return;
+
+    // Convert from big-endian
+    codeDir.magic       = CFSwapInt32BigToHost(codeDir.magic);
+    codeDir.length      = CFSwapInt32BigToHost(codeDir.length);
+    codeDir.version     = CFSwapInt32BigToHost(codeDir.version);
+    codeDir.flags       = CFSwapInt32BigToHost(codeDir.flags);
+    codeDir.identOffset = CFSwapInt32BigToHost(codeDir.identOffset);
+
+    if (codeDir.magic != 0xfade0c02)
+        return; // CSMAGIC_CODEDIRECTORY
+
+    info[@"codeDirectoryVersion"] = @(codeDir.version);
+    info[@"codeDirectoryFlags"]   = @(codeDir.flags);
+    info[@"hashType"]             = @(codeDir.hashType);
+    info[@"platform"]             = @(codeDir.platform);
+
+    // Read application identifier from CodeDirectory
+    if (codeDir.identOffset > 0 && codeDir.identOffset < codeDir.length)
+    {
+        if (fseek(file, offset + codeDir.identOffset, SEEK_SET) == 0)
+        {
+            // Read up to 256 characters or until null terminator
+            char   identifier[257] = {0}; // Extra space for safety
+            size_t maxRead         = MIN(256, codeDir.length - codeDir.identOffset);
+            size_t bytesRead       = fread(identifier, 1, maxRead, file);
+
+            if (bytesRead > 0)
+            {
+                // Ensure null termination
+                identifier[bytesRead] = '\0';
+
+                // Find actual string length (stop at first null)
+                size_t strLen = strnlen(identifier, bytesRead);
+                if (strLen > 0)
+                {
+                    NSString *applicationIdentifier = [NSString stringWithUTF8String:identifier];
+                    if (applicationIdentifier && applicationIdentifier.length > 0)
+                    {
+                        info[@"applicationIdentifier"] = applicationIdentifier;
+                        [Logger debug:LOG_CATEGORY_UTILITIES
+                               format:@"Read application identifier: %@", applicationIdentifier];
+                    }
+                }
+            }
+        }
+    }
+}
+
++ (void)readEntitlements:(FILE *)file offset:(uint32_t)offset info:(NSMutableDictionary *)info
+{
+    if (fseek(file, offset, SEEK_SET) != 0)
+        return;
+
+    struct {
+        uint32_t magic;
+        uint32_t length;
+    } blobHeader;
+
+    if (fread(&blobHeader, sizeof(blobHeader), 1, file) != 1)
+        return;
+
+    blobHeader.magic  = CFSwapInt32BigToHost(blobHeader.magic);
+    blobHeader.length = CFSwapInt32BigToHost(blobHeader.length);
+
+    if (blobHeader.magic != 0xfade7171)
+        return; // CSMAGIC_EMBEDDED_ENTITLEMENTS
+
+    uint32_t       entitlementsLength = blobHeader.length - 8;
+    NSMutableData *entitlementsData   = [NSMutableData dataWithLength:entitlementsLength];
+
+    if (fread([entitlementsData mutableBytes], entitlementsLength, 1, file) != 1)
+        return;
+
+    NSError      *error        = nil;
+    NSDictionary *entitlements = [NSPropertyListSerialization propertyListWithData:entitlementsData
+                                                                           options:0
+                                                                            format:nil
+                                                                             error:&error];
+
+    if (!error && entitlements)
+    {
+        info[@"entitlements"]     = entitlements;
+        info[@"entitlementsSize"] = @(entitlementsLength);
+    }
+}
+
++ (void)readCMSSignature:(FILE *)file offset:(uint32_t)offset info:(NSMutableDictionary *)info
+{
+    if (fseek(file, offset, SEEK_SET) != 0)
+        return;
+
+    struct {
+        uint32_t magic;
+        uint32_t length;
+    } blobHeader;
+
+    if (fread(&blobHeader, sizeof(blobHeader), 1, file) != 1)
+        return;
+
+    blobHeader.magic  = CFSwapInt32BigToHost(blobHeader.magic);
+    blobHeader.length = CFSwapInt32BigToHost(blobHeader.length);
+
+    if (blobHeader.magic != 0xfade0b01)
+        return; // CSMAGIC_BLOBWRAPPER
+
+    info[@"cmsSignatureSize"] = @(blobHeader.length - 8);
+    info[@"hasCMSSignature"]  = @YES;
+
+    // Try to extract some basic info from the CMS signature
+    uint32_t cmsLength = blobHeader.length - 8;
+    if (cmsLength > 0 && cmsLength < 1024 * 1024) // Reasonable size limit
+    {
+        NSMutableData *cmsData = [NSMutableData dataWithLength:cmsLength];
+        if (fread([cmsData mutableBytes], cmsLength, 1, file) == 1)
+        {
+            // Look for Apple-specific OIDs or common certificate info
+            if (cmsLength > 20)
+            {
+                // Simple heuristic: look for "Apple" string in the signature
+                NSString *cmsString = [[NSString alloc] initWithData:cmsData
+                                                            encoding:NSASCIIStringEncoding];
+                if ([cmsString containsString:@"Apple"])
+                {
+                    info[@"signerInfo"] = @"Apple";
+                }
+                else if ([cmsString containsString:@"Developer"])
+                {
+                    info[@"signerInfo"] = @"Developer";
+                }
+                else
+                {
+                    info[@"signerInfo"] = @"Unknown";
+                }
+            }
+        }
+    }
+}
+
++ (NSString *)formatEntitlementsAsPlist:(NSDictionary *)entitlements
+{
+    if (!entitlements || entitlements.count == 0)
+    {
+        return nil;
+    }
+
+    NSError *error = nil;
+    NSData  *plistData =
+        [NSPropertyListSerialization dataWithPropertyList:entitlements
+                                                   format:NSPropertyListXMLFormat_v1_0
+                                                  options:0
+                                                    error:&error];
+
+    if (error || !plistData)
+    {
+        [Logger error:LOG_CATEGORY_UTILITIES
+               format:@"Failed to serialize entitlements: %@", error.localizedDescription];
+        return nil;
+    }
+
+    NSString *plistString = [[NSString alloc] initWithData:plistData encoding:NSUTF8StringEncoding];
+    return plistString;
+}
+
++ (void)logApplicationSignatureInfo
+{
+    [Logger info:LOG_CATEGORY_UTILITIES format:@"=== Application Signature Information ==="];
+
+    NSBundle *bundle         = [NSBundle mainBundle];
+    NSString *bundleId       = bundle.bundleIdentifier;
+    NSString *executableName = bundle.infoDictionary[@"CFBundleExecutable"];
+
+    [Logger info:LOG_CATEGORY_UTILITIES format:@"Bundle ID: %@", bundleId ?: @"Unknown"];
+    [Logger info:LOG_CATEGORY_UTILITIES format:@"Executable: %@", executableName ?: @"Unknown"];
+
+    // Get app source information
+    NSString *appSource;
+    if ([self isAppStoreApp])
+    {
+        appSource = @"App Store";
+    }
+    else if ([self isTestFlightApp])
+    {
+        appSource = @"TestFlight";
+    }
+    else if ([self isTrollStoreApp])
+    {
+        appSource = [self getTrollStoreVariant];
+    }
+    else
+    {
+        appSource = @"Sideloaded";
+    }
+
+    [Logger info:LOG_CATEGORY_UTILITIES format:@"App Source: %@", appSource];
+    [Logger info:LOG_CATEGORY_UTILITIES
+          format:@"System App: %@", [self isSystemApp] ? @"YES" : @"NO"];
+
+    // Read and log signature information
+    NSDictionary *signatureInfo = [self getApplicationSignatureInfo];
+
+    if (signatureInfo.count > 0)
+    {
+        // Log signature metadata
+        if (signatureInfo[@"applicationIdentifier"])
+        {
+            [Logger info:LOG_CATEGORY_UTILITIES
+                  format:@"Application Identifier: %@", signatureInfo[@"applicationIdentifier"]];
+        }
+
+        if (signatureInfo[@"blobTypes"])
+        {
+            NSArray *types = signatureInfo[@"blobTypes"];
+            [Logger info:LOG_CATEGORY_UTILITIES
+                  format:@"Signature Blobs: %@", [types componentsJoinedByString:@", "]];
+        }
+
+        if (signatureInfo[@"signerInfo"])
+        {
+            [Logger info:LOG_CATEGORY_UTILITIES format:@"Signer: %@", signatureInfo[@"signerInfo"]];
+        }
+
+        if (signatureInfo[@"signatureSize"])
+        {
+            [Logger info:LOG_CATEGORY_UTILITIES
+                  format:@"Signature Size: %@ bytes", signatureInfo[@"signatureSize"]];
+        }
+    }
+    else
+    {
+        [Logger info:LOG_CATEGORY_UTILITIES format:@"No signature information found"];
+    }
+
+    [Logger info:LOG_CATEGORY_UTILITIES format:@"=== End Signature Information ==="];
 }
 
 // TODO: remove before initial release


### PR DESCRIPTION
this pr

- cleans up the mobilegestalt impl to only grab the keys we want
- resolves the oversight in sideloading checks that previously didn't detect TestFlight installs
- dynamically determines the existence of th dynamic island rather than hardcoding device identifiers
- ability to detect trollstore and trollstore lite as app sources
- more detailed github issue body prefill
- extract current entitlements and append them to the GitHub issue body
- download hbc bundle by default