### PR TITLE
feat(hmr): opt-in live reload via SSE

### DIFF
--- a/.vscode/build-actions.sh
+++ b/.vscode/build-actions.sh
@@ -34,7 +34,9 @@ case "$ACTION" in
 
     REMOTE_DEB="/tmp/$(basename "$DEB")"
 
-    sshpass -p alpine scp -P 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$DEB" "$SSH_TARGET:$REMOTE_DEB"
+    # -O forces the legacy SCP/rcp protocol: the vphone's dropbear has no sftp-server,
+    # which modern scp defaults to (fails with "/usr/libexec/sftp-server: No such file").
+    sshpass -p alpine scp -O -P 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$DEB" "$SSH_TARGET:$REMOTE_DEB"
     sshpass -p alpine ssh $SSH_OPTS "$SSH_TARGET" "echo 'alpine' | sudo -S dpkg -i '$REMOTE_DEB' && echo 'alpine' | sudo -S killall -9 Discord; uiopen --bundleid com.hammerandchisel.discord"
     ;;
   Package)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ The resulting `.deb` file will be in the `packages` folder.
 
 </details>
 
+## Live reload (HMR)
+
+When working on the [JavaScript client](https://github.com/unbound-app/client) you can have the
+app reload automatically whenever you rebuild the bundle, instead of relaunching by hand.
+
+1. Run the client's dev server (`bun scripts/dev` in the client repo). It serves the bundle and a
+   Server-Sent Events stream at `/__hot`.
+2. In Unbound's settings, set:
+   - `loader.update.url` to your dev server's bundle URL, e.g. `http://<your-LAN-ip>:3000/unbound.bundle`
+   - `loader.update.hmr` to `true`
+3. Launch Discord. The loader connects to `<origin>/__hot`; when you edit a file and the dev
+   server rebuilds, the app re-fetches the bundle and reloads automatically.
+
+`loader.update.hmr` is off by default, so this never runs for normal users. The HMR endpoint is
+derived from `loader.update.url`'s origin — no separate setting needed.
+
 ## Contributors
 
 [![Contributors](https://contrib.rocks/image?repo=unbound-app/loader-ios)](https://github.com/unbound-app/loader-ios/graphs/contributors)

--- a/headers/FileSystem.h
+++ b/headers/FileSystem.h
@@ -1,5 +1,25 @@
 #import "Unbound.h"
 
+// A vnode watch on a single file's inode. In-place writes fire its event directly; an
+// atomic/replacing write (write-temp + rename, or delete + recreate) swaps the inode, so the
+// source goes silent and is re-armed by the parent DirectoryWatcher on the new inode.
+@interface FileMonitor : NSObject
+@property (copy) NSString           *path;
+@property (copy) dispatch_block_t    onChange;
+@property (strong) dispatch_source_t fileSource;
+@property (strong) dispatch_source_t debounceTimer;
+@property (strong) dispatch_queue_t  queue;
+@end
+
+// A single vnode watch shared by every FileMonitor living in the same parent directory. The kernel
+// event doesn't name the changed file, so it fans out to all monitors under the directory; this is
+// the only signal that catches inode-swapping writes the per-file source can't see.
+@interface DirectoryWatcher : NSObject
+@property (copy) NSString                   *path;
+@property (strong) dispatch_source_t         source;
+@property (strong) NSMutableSet<NSString *> *files;
+@end
+
 @interface FileSystem : NSObject
 {
     NSFileManager *manager;
@@ -17,6 +37,13 @@
 + (NSHTTPURLResponse *)download:(NSURL *)url path:(NSString *)path;
 
 + (void)monitor:(NSString *)filePath onChange:(void (^)())onChange autoRestart:(BOOL)autoRestart;
++ (void)stopMonitoring:(NSString *)path;
+
++ (DirectoryWatcher *)watcherForDirectory:(NSString *)dirPath queue:(dispatch_queue_t)queue;
++ (void)releaseDirectoryWatcherFor:(NSString *)dirPath;
++ (void)handleDirectoryEvent:(NSString *)dirPath;
++ (void)armFileSource:(FileMonitor *)monitor;
++ (void)scheduleNotify:(FileMonitor *)monitor;
 
 + (NSArray *)readDirectory:(NSString *)path;
 + (NSData *)readFile:(NSString *)path;

--- a/headers/HotReload.h
+++ b/headers/HotReload.h
@@ -1,0 +1,27 @@
+#import "Unbound.h"
+
+// Opt-in live reload (HMR), gated behind the `loader.update.hmr` setting. When enabled, streams
+// the dev server's `/__hot` Server-Sent Events endpoint (derived from `loader.update.url`) and
+// reloads the app whenever the bundle changes. Toggling the setting starts/stops it without a
+// relaunch.
+@interface HotReload : NSObject <NSURLSessionDataDelegate>
+
++ (instancetype)shared;
+
+// Start watching `loader.update.hmr` and apply its current value. Idempotent.
++ (void)observe;
+
+// Start or stop the stream to match the current `loader.update.hmr` value.
++ (void)sync;
+
+- (void)start;
+- (void)stop;
+- (void)sync;
+- (void)connect;
+- (void)scheduleReconnect;
+- (NSURL *)resolveHotURL;
+- (void)drainBuffer;
+- (void)handleEvent:(NSString *)event;
+- (void)handleReloadEtag:(NSString *)incoming;
+
+@end

--- a/headers/Settings.h
+++ b/headers/Settings.h
@@ -1,5 +1,14 @@
 #import "Unbound.h"
 
+// Posted whenever settings.json changes so features can react to a live setting toggle.
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern NSString *const UnboundSettingsDidChangeNotification;
+#ifdef __cplusplus
+}
+#endif
+
 @interface Settings : NSObject
 {
     NSDictionary *data;

--- a/sources/FileSystem.m
+++ b/sources/FileSystem.m
@@ -1,9 +1,40 @@
 #import "FileSystem.h"
 
+static const NSTimeInterval kMonitorDebounce = 0.250;
+
+static const unsigned long kFileVnodeMask =
+    DISPATCH_VNODE_ATTRIB | DISPATCH_VNODE_DELETE | DISPATCH_VNODE_EXTEND | DISPATCH_VNODE_LINK |
+    DISPATCH_VNODE_RENAME | DISPATCH_VNODE_REVOKE | DISPATCH_VNODE_WRITE;
+
+static const unsigned long kFileGoneMask =
+    DISPATCH_VNODE_DELETE | DISPATCH_VNODE_RENAME | DISPATCH_VNODE_REVOKE;
+
+static const unsigned long kDirVnodeMask =
+    DISPATCH_VNODE_WRITE | DISPATCH_VNODE_DELETE | DISPATCH_VNODE_RENAME;
+
+@implementation FileMonitor
+@end
+
+@implementation DirectoryWatcher
+@end
+
 @implementation FileSystem
-static NSMutableDictionary<NSString *, NSMutableDictionary *> *monitors  = nil;
-static NSFileManager                                          *manager   = nil;
-static NSString                                               *documents = nil;
+static NSMutableDictionary<NSString *, FileMonitor *>      *monitors    = nil;
+static NSMutableDictionary<NSString *, DirectoryWatcher *> *dirWatchers = nil;
+static NSFileManager                                       *manager     = nil;
+static NSString                                            *documents   = nil;
+
+// Serialises all mutation of monitors/dirWatchers and their sources, which is driven from several
+// queues (registration, directory event handlers, stopMonitoring:).
+static dispatch_queue_t monitorRegistryQueue(void)
+{
+    static dispatch_queue_t queue;
+    static dispatch_once_t  once;
+    dispatch_once(&once, ^{
+        queue = dispatch_queue_create("app.unbound.fs.monitors", DISPATCH_QUEUE_SERIAL);
+    });
+    return queue;
+}
 
 + (BOOL)exists:(NSString *)path
 {
@@ -90,86 +121,188 @@ static NSString                                               *documents = nil;
 
 + (void)monitor:(NSString *)filePath onChange:(void (^)())onChange autoRestart:(BOOL)autoRestart
 {
-    if ([monitors objectForKey:filePath])
-    {
-        return;
-    }
-
-    const char *path = [filePath fileSystemRepresentation];
-
-    int fdescriptor = open(path, O_EVTONLY);
-
-    if (fdescriptor < 0)
-    {
-        [Logger error:LOG_CATEGORY_FILESYSTEM
-               format:@"Failed to open %@ for monitoring (errno %d)", filePath, errno];
-        return;
-    }
-
-    dispatch_queue_t defaultQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-    dispatch_source_t source = dispatch_source_create(
-        DISPATCH_SOURCE_TYPE_VNODE, fdescriptor,
-        DISPATCH_VNODE_ATTRIB | DISPATCH_VNODE_DELETE | DISPATCH_VNODE_EXTEND |
-            DISPATCH_VNODE_LINK | DISPATCH_VNODE_RENAME | DISPATCH_VNODE_REVOKE |
-            DISPATCH_VNODE_WRITE,
-        defaultQueue);
-
-
-    NSMutableDictionary *monitor = [[NSMutableDictionary alloc] init];
-
-    monitor[@"cancel"] = ^{
-        dispatch_source_cancel(source);
-
-        [monitors removeObjectForKey:filePath];
-        [Logger debug:LOG_CATEGORY_FILESYSTEM format:@"monitor for %@ was destroyed", filePath];
-    };
-
-    monitor[@"debounce_timer"] = nil;
-
-    [monitors setValue:monitor forKey:filePath];
-
-    dispatch_source_set_event_handler(source, ^{
-        if (monitor[@"debounce_timer"] != nil)
+    dispatch_async(monitorRegistryQueue(), ^{
+        if (!monitors)
         {
-            dispatch_source_cancel(monitor[@"debounce_timer"]);
-            monitor[@"debounce_timer"] = nil;
+            monitors = [NSMutableDictionary dictionary];
+        }
+        if (!dirWatchers)
+        {
+            dirWatchers = [NSMutableDictionary dictionary];
+        }
+        if (monitors[filePath])
+        {
+            return;
         }
 
-        dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-        double           secondsToThrottle = 0.250f;
-        monitor[@"debounce_timer"]         = [Utilities createDebounceTimer:secondsToThrottle
-                                                              queue:queue
-                                                              block:^{ onChange(); }];
+        FileMonitor *monitor = [[FileMonitor alloc] init];
+        monitor.path         = filePath;
+        monitor.onChange     = onChange;
+        monitor.queue        = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+        monitors[filePath]   = monitor;
+
+        DirectoryWatcher *dir =
+            [FileSystem watcherForDirectory:monitor.path.stringByDeletingLastPathComponent
+                                      queue:monitor.queue];
+        [dir.files addObject:filePath];
+
+        // OK if this is a no-op now (file absent) - the directory watcher arms it once it appears.
+        [FileSystem armFileSource:monitor];
     });
-
-    dispatch_source_set_cancel_handler(source, ^(void) {
-        [Logger debug:LOG_CATEGORY_FILESYSTEM
-               format:@"event listener got cancelled for %@", filePath];
-        close(fdescriptor);
-
-        if (autoRestart)
-        {
-            [Logger debug:LOG_CATEGORY_FILESYSTEM format:@"Restarting file watcher."];
-            [FileSystem monitor:filePath onChange:onChange autoRestart:autoRestart];
-        }
-    });
-
-    dispatch_resume(source);
 }
 
 + (void)stopMonitoring:(NSString *)path
 {
-    if (!monitors)
+    dispatch_async(monitorRegistryQueue(), ^{
+        FileMonitor *monitor = monitors[path];
+        if (!monitor)
+        {
+            return;
+        }
+
+        if (monitor.fileSource)
+        {
+            dispatch_source_cancel(monitor.fileSource);
+        }
+        if (monitor.debounceTimer)
+        {
+            dispatch_source_cancel(monitor.debounceTimer);
+        }
+
+        [monitors removeObjectForKey:path];
+        [FileSystem releaseDirectoryWatcherFor:path.stringByDeletingLastPathComponent];
+
+        [Logger debug:LOG_CATEGORY_FILESYSTEM format:@"monitor for %@ was destroyed", path];
+    });
+}
+
+#pragma mark - Monitoring internals (run on monitorRegistryQueue)
+
+// Reuses the directory's existing watcher when one is present, creating it otherwise. The returned
+// watcher fans every event to all FileMonitors registered in its `files` set.
++ (DirectoryWatcher *)watcherForDirectory:(NSString *)dirPath queue:(dispatch_queue_t)queue
+{
+    DirectoryWatcher *existing = dirWatchers[dirPath];
+    if (existing)
+    {
+        return existing;
+    }
+
+    DirectoryWatcher *watcher = [[DirectoryWatcher alloc] init];
+    watcher.path              = dirPath;
+    watcher.files             = [NSMutableSet set];
+    dirWatchers[dirPath]      = watcher;
+
+    int fd = open(dirPath.fileSystemRepresentation, O_EVTONLY);
+    if (fd < 0)
+    {
+        [Logger error:LOG_CATEGORY_FILESYSTEM
+               format:@"Failed to open dir %@ for monitoring (errno %d)", dirPath, errno];
+        return watcher;
+    }
+
+    watcher.source = dispatch_source_create(DISPATCH_SOURCE_TYPE_VNODE, fd, kDirVnodeMask, queue);
+
+    dispatch_source_set_event_handler(watcher.source, ^{
+        dispatch_sync(monitorRegistryQueue(), ^{ [FileSystem handleDirectoryEvent:dirPath]; });
+    });
+    dispatch_source_set_cancel_handler(watcher.source, ^{ close(fd); });
+
+    dispatch_resume(watcher.source);
+    return watcher;
+}
+
++ (void)handleDirectoryEvent:(NSString *)dirPath
+{
+    for (NSString *file in [dirWatchers[dirPath].files copy])
+    {
+        FileMonitor *monitor = monitors[file];
+        if (!monitor.fileSource)
+        {
+            [FileSystem armFileSource:monitor];
+        }
+        [FileSystem scheduleNotify:monitor];
+    }
+}
+
+// Drops the shared directory watcher once it no longer serves any files.
++ (void)releaseDirectoryWatcherFor:(NSString *)dirPath
+{
+    DirectoryWatcher *watcher = dirWatchers[dirPath];
+    [watcher.files removeObject:dirPath];
+
+    if (watcher.files.count == 0)
+    {
+        if (watcher.source)
+        {
+            dispatch_source_cancel(watcher.source);
+        }
+        [dirWatchers removeObjectForKey:dirPath];
+    }
+}
+
+// Opens a vnode source on the file's current inode. No-op if absent or already armed.
++ (void)armFileSource:(FileMonitor *)monitor
+{
+    if (!monitor || monitor.fileSource)
     {
         return;
     }
 
-    NSMutableDictionary *monitor = [monitors valueForKey:path];
-    void (^block)(void)          = monitor[@"cancel"];
-    if (block)
+    int fd = open(monitor.path.fileSystemRepresentation, O_EVTONLY);
+    if (fd < 0)
     {
-        block();
+        return;
     }
+
+    dispatch_source_t source =
+        dispatch_source_create(DISPATCH_SOURCE_TYPE_VNODE, fd, kFileVnodeMask, monitor.queue);
+
+    dispatch_source_set_event_handler(source, ^{
+        unsigned long flags = dispatch_source_get_data(source);
+        dispatch_sync(monitorRegistryQueue(), ^{ [FileSystem scheduleNotify:monitor]; });
+
+        // Inode replaced/removed: drop this watch so the directory watcher re-arms us on the new
+        // one.
+        if (flags & kFileGoneMask)
+        {
+            dispatch_sync(monitorRegistryQueue(), ^{
+                if (monitor.fileSource == source)
+                {
+                    monitor.fileSource = nil;
+                }
+            });
+            dispatch_source_cancel(source);
+        }
+    });
+    dispatch_source_set_cancel_handler(source, ^{ close(fd); });
+
+    monitor.fileSource = source;
+    dispatch_resume(source);
+}
+
+// Coalesces bursts of events (an atomic write can fire several) into one debounced onChange.
++ (void)scheduleNotify:(FileMonitor *)monitor
+{
+    if (!monitor)
+    {
+        return;
+    }
+
+    if (monitor.debounceTimer)
+    {
+        dispatch_source_cancel(monitor.debounceTimer);
+    }
+
+    dispatch_block_t onChange = monitor.onChange;
+    monitor.debounceTimer     = [Utilities createDebounceTimer:kMonitorDebounce
+                                                     queue:monitor.queue
+                                                     block:^{
+                                                         if (onChange)
+                                                         {
+                                                             onChange();
+                                                         }
+                                                     }];
 }
 
 + (NSHTTPURLResponse *)download:(NSURL *)url path:(NSString *)path
@@ -181,12 +314,12 @@ static NSString                                               *documents = nil;
                            path:(NSString *)path
                     withHeaders:(NSDictionary *)headers
 {
-    static NSURLSession *bundleUrlSession = nil;
+    static NSURLSession   *bundleUrlSession = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
         config.timeoutIntervalForRequest  = 30.0;
-        bundleUrlSession = [NSURLSession sessionWithConfiguration:config];
+        bundleUrlSession                  = [NSURLSession sessionWithConfiguration:config];
     });
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);

--- a/sources/HotReload.xm
+++ b/sources/HotReload.xm
@@ -1,0 +1,345 @@
+#import "HotReload.h"
+
+static const NSTimeInterval kReconnectMinDelay = 1.0;
+static const NSTimeInterval kReconnectMaxDelay = 30.0;
+
+@implementation HotReload
+{
+    // All state below is mutated only on _queue, so the public API, the reconnect timer, and the
+    // URLSession delegate callbacks can't race.
+    dispatch_queue_t      _queue;
+    NSURLSession         *_session;
+    NSURLSessionDataTask *_task;
+    NSURL                *_url;
+    NSMutableData        *_buffer;
+    NSTimeInterval        _reconnectDelay;
+    BOOL                  _running;
+    uint64_t              _generation;
+}
+
++ (instancetype)shared
+{
+    static HotReload      *shared    = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ shared = [[HotReload alloc] init]; });
+    return shared;
+}
+
++ (void)observe
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        HotReload *shared = [HotReload shared];
+
+        [[NSNotificationCenter defaultCenter] addObserver:shared
+                                                 selector:@selector(sync)
+                                                     name:UnboundSettingsDidChangeNotification
+                                                   object:nil];
+
+        [shared sync];
+    });
+}
+
++ (void)sync
+{
+    [[HotReload shared] sync];
+}
+
+- (instancetype)init
+{
+    if ((self = [super init]))
+    {
+        _queue          = dispatch_queue_create("app.unbound.hotreload", DISPATCH_QUEUE_SERIAL);
+        _buffer         = [NSMutableData data];
+        _reconnectDelay = kReconnectMinDelay;
+    }
+
+    return self;
+}
+
+- (void)sync
+{
+    BOOL enabled = [Settings getBoolean:@"unbound" key:@"loader.update.hmr" def:NO];
+
+    dispatch_async(_queue, ^{
+        if (enabled && !self->_running)
+        {
+            [self start];
+        }
+        else if (!enabled && self->_running)
+        {
+            [self stop];
+        }
+    });
+}
+
+- (void)start
+{
+    if (_running)
+    {
+        return;
+    }
+
+    _url = [self resolveHotURL];
+    if (!_url)
+    {
+        [Logger info:LOG_CATEGORY_UPDATER
+              format:@"Hot-reload: no dev server origin resolved; live reload not started."];
+        return;
+    }
+
+    _running        = YES;
+    _reconnectDelay = kReconnectMinDelay;
+
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+
+    // The SSE stream is long-lived, so disable the request/resource timeouts.
+    config.timeoutIntervalForRequest  = 86400.0;
+    config.timeoutIntervalForResource = DBL_MAX;
+    config.HTTPAdditionalHeaders      = @{
+        @"Accept" : @"text/event-stream",
+        @"Cache-Control" : @"no-cache",
+    };
+
+    NSOperationQueue *delegateQueue           = [[NSOperationQueue alloc] init];
+    delegateQueue.underlyingQueue             = _queue;
+    delegateQueue.maxConcurrentOperationCount = 1;
+
+    _session = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:delegateQueue];
+
+    [Logger info:LOG_CATEGORY_UPDATER format:@"Hot-reload: enabled."];
+    [self connect];
+}
+
+- (void)stop
+{
+    if (!_running)
+    {
+        return;
+    }
+
+    // Bumping the generation makes any reconnect already scheduled before this stop a no-op.
+    _running = NO;
+    _generation++;
+
+    [_task cancel];
+    _task = nil;
+
+    [_session invalidateAndCancel];
+    _session = nil;
+
+    [_buffer setLength:0];
+
+    [Logger info:LOG_CATEGORY_UPDATER format:@"Hot-reload: disabled; stream stopped."];
+}
+
+// Reduces `loader.update.url` (a direct bundle URL or a directory) to its origin + `/__hot`.
+- (NSURL *)resolveHotURL
+{
+    NSString *base = [Settings getString:@"unbound" key:@"loader.update.url" def:@""];
+    if (base.length == 0)
+    {
+        return nil;
+    }
+
+    NSURLComponents *components = [NSURLComponents componentsWithString:base];
+    if (!components.scheme || !components.host)
+    {
+        return nil;
+    }
+
+    NSURLComponents *origin = [[NSURLComponents alloc] init];
+    origin.scheme           = components.scheme;
+    origin.host             = components.host;
+    origin.port             = components.port;
+    origin.path             = @"/__hot";
+
+    return origin.URL;
+}
+
+- (void)connect
+{
+    if (!_running || !_session)
+    {
+        return;
+    }
+
+    [_buffer setLength:0];
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:_url];
+    request.cachePolicy          = NSURLRequestReloadIgnoringCacheData;
+
+    [Logger info:LOG_CATEGORY_UPDATER format:@"Hot-reload: connecting SSE to %@", _url];
+
+    _task = [_session dataTaskWithRequest:request];
+    [_task resume];
+}
+
+- (void)scheduleReconnect
+{
+    if (!_running)
+    {
+        return;
+    }
+
+    NSTimeInterval delay      = _reconnectDelay;
+    _reconnectDelay           = MIN(_reconnectDelay * 2.0, kReconnectMaxDelay);
+    uint64_t       generation = _generation;
+
+    [Logger info:LOG_CATEGORY_UPDATER format:@"Hot-reload: reconnecting in %.0fs.", delay];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (delay * NSEC_PER_SEC)), _queue, ^{
+        if (!self->_running || self->_generation != generation)
+        {
+            return;
+        }
+        [self connect];
+    });
+}
+
+#pragma mark - SSE parsing
+
+- (void)drainBuffer
+{
+    NSData *separator = [@"\n\n" dataUsingEncoding:NSUTF8StringEncoding];
+
+    while (YES)
+    {
+        NSRange range = [_buffer rangeOfData:separator options:0 range:NSMakeRange(0, _buffer.length)];
+        if (range.location == NSNotFound)
+        {
+            break;
+        }
+
+        NSData   *eventData = [_buffer subdataWithRange:NSMakeRange(0, range.location)];
+        NSString *event     = [[NSString alloc] initWithData:eventData encoding:NSUTF8StringEncoding];
+
+        [_buffer replaceBytesInRange:NSMakeRange(0, range.location + range.length)
+                           withBytes:NULL
+                              length:0];
+
+        if (event.length)
+        {
+            [self handleEvent:event];
+        }
+    }
+}
+
+- (void)handleEvent:(NSString *)event
+{
+    NSString *eventName = nil;
+    NSString *eventData = nil;
+
+    for (NSString *line in [event componentsSeparatedByString:@"\n"])
+    {
+        // Lines starting with ':' are SSE comments (used here as keepalive pings).
+        if (line.length == 0 || [line hasPrefix:@":"])
+        {
+            continue;
+        }
+
+        if ([line hasPrefix:@"event:"])
+        {
+            eventName = [[line substringFromIndex:6]
+                stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        }
+        else if ([line hasPrefix:@"data:"])
+        {
+            eventData = [[line substringFromIndex:5]
+                stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        }
+    }
+
+    if (![eventName isEqualToString:@"reload"] || eventData.length == 0)
+    {
+        return;
+    }
+
+    NSData *json    = [eventData dataUsingEncoding:NSUTF8StringEncoding];
+    id      payload = [Utilities parseJSON:json];
+
+    if (![payload isKindOfClass:[NSDictionary class]])
+    {
+        return;
+    }
+
+    NSString *incoming = payload[@"etag"];
+    if (![incoming isKindOfClass:[NSString class]])
+    {
+        return;
+    }
+
+    [self handleReloadEtag:incoming];
+}
+
+- (void)handleReloadEtag:(NSString *)incoming
+{
+    NSString *stored = [Settings getString:@"unbound" key:@"loader.update.etag" def:@""];
+
+    if (stored.length > 0 && [stored isEqualToString:incoming])
+    {
+        [Logger info:LOG_CATEGORY_UPDATER
+              format:@"Hot-reload: etag unchanged (%@); skipping reload.", incoming];
+        return;
+    }
+
+    [Logger info:LOG_CATEGORY_UPDATER
+          format:@"Hot-reload: etag mismatch (stored %@, incoming %@) -> reloadApp.",
+                 stored.length ? stored : @"<none>", incoming];
+
+    // The reload re-runs the launch-time download path, which re-fetches the new bundle.
+    [Utilities reloadApp];
+}
+
+#pragma mark - NSURLSessionDataDelegate
+
+- (void)URLSession:(NSURLSession *)session
+          dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveResponse:(NSURLResponse *)response
+     completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
+{
+    NSInteger status = [(NSHTTPURLResponse *) response statusCode];
+
+    if (status == 200)
+    {
+        _reconnectDelay = kReconnectMinDelay;
+        [Logger info:LOG_CATEGORY_UPDATER format:@"Hot-reload: SSE connected."];
+        completionHandler(NSURLSessionResponseAllow);
+    }
+    else
+    {
+        completionHandler(NSURLSessionResponseCancel);
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session
+          dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveData:(NSData *)data
+{
+    [_buffer appendData:data];
+    [self drainBuffer];
+}
+
+- (void)URLSession:(NSURLSession *)session
+                    task:(NSURLSessionTask *)task
+    didCompleteWithError:(NSError *)error
+{
+    if (!_running)
+    {
+        return;
+    }
+
+    if (error)
+    {
+        [Logger info:LOG_CATEGORY_UPDATER
+              format:@"Hot-reload: SSE disconnected (%@).", error.localizedDescription];
+    }
+    else
+    {
+        [Logger info:LOG_CATEGORY_UPDATER format:@"Hot-reload: SSE stream closed."];
+    }
+
+    [self scheduleReconnect];
+}
+
+@end

--- a/sources/Settings.m
+++ b/sources/Settings.m
@@ -1,5 +1,7 @@
 #import "Settings.h"
 
+NSString *const UnboundSettingsDidChangeNotification = @"UnboundSettingsDidChange";
+
 @implementation Settings
 static NSMutableDictionary *data = nil;
 static NSString            *path = nil;
@@ -10,7 +12,14 @@ static NSString            *path = nil;
 
     [Settings loadSettings];
 
-    [FileSystem monitor:path onChange:^{ [Settings loadSettings]; } autoRestart:YES];
+    [FileSystem monitor:path
+               onChange:^{
+                   [Settings loadSettings];
+                   [[NSNotificationCenter defaultCenter]
+                       postNotificationName:UnboundSettingsDidChangeNotification
+                                     object:nil];
+               }
+            autoRestart:YES];
 }
 
 + (void)loadSettings
@@ -122,8 +131,6 @@ static NSString            *path = nil;
 
 + (NSString *)getSettings
 {
-    return [Utilities JSONStringFromObject:data
-                                   options:NSJSONWritingPrettyPrinted
-                                  fallback:@"{}"];
+    return [Utilities JSONStringFromObject:data options:NSJSONWritingPrettyPrinted fallback:@"{}"];
 }
 @end

--- a/sources/Unbound.xm
+++ b/sources/Unbound.xm
@@ -1,6 +1,7 @@
 #import <jsi/jsi.h>
 
 #import "Discord.h"
+#import "HotReload.h"
 #import "JSI.h"
 #import "LoaderShared.h"
 #import "RCTHost.h"
@@ -48,92 +49,104 @@ static void injectUnboundPreBundle(jsi::Runtime &runtime)
     }
 }
 
-// Unbound's bundle is enqueued only after Discord's has been scheduled, so that the
-// FIFO executor runs it second and globalThis.modules (populated by Discord) exists
-// when it initializes. The semaphore lets the post-Discord hook wait for the download.
+// Unbound's bundle is enqueued only after Discord's has been scheduled so the FIFO executor runs
+// it second, once globalThis.modules (populated by Discord) exists. The semaphore lets the
+// post-Discord hook wait for the download.
+//
+// These run once per bundle load, not once per process, so a reload (which re-fires the hooks)
+// re-fetches and re-evaluates the bundle. gPrefetchToken discards a download from a load that was
+// superseded by a newer one before it finished.
 static NSData              *gUnboundBundle    = nil;
 static dispatch_semaphore_t gUnboundBundleSem = nil;
+static uint64_t             gPrefetchToken    = 0;
 
 static void prefetchUnboundBundle(void)
 {
-    static dispatch_once_t once;
-    dispatch_once(&once, ^{
-        gUnboundBundleSem = dispatch_semaphore_create(0);
+    uint64_t token = ++gPrefetchToken;
 
-        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-            NSString *bundlePath = [Updater resolveBundlePath];
+    gUnboundBundle    = nil;
+    gUnboundBundleSem = dispatch_semaphore_create(0);
 
-            @try
-            {
-                bundlePath = [Updater downloadBundle:bundlePath];
-            }
-            @catch (NSException *e)
-            {
-                [Logger error:LOG_CATEGORY_DEFAULT format:@"Bundle download failed. (%@)", e];
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSString *bundlePath = [Updater resolveBundlePath];
 
-                if (![FileSystem exists:bundlePath])
-                {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        [Utilities alert:@"Bundle failed to download, please report this "
-                                         @"to the developers."];
-                    });
-                }
-                else
-                {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        [Utilities alert:@"Bundle failed to update, loading out of date bundle."];
-                    });
-                }
-            }
+        @try
+        {
+            bundlePath = [Updater downloadBundle:bundlePath];
+        }
+        @catch (NSException *e)
+        {
+            [Logger error:LOG_CATEGORY_DEFAULT format:@"Bundle download failed. (%@)", e];
 
-            if ([FileSystem exists:bundlePath])
-            {
-                NSData *bundle = [FileSystem readFile:bundlePath];
-                if (bundle.length)
-                {
-                    gUnboundBundle = bundle;
-                }
-            }
-
-            if (!gUnboundBundle)
+            if (![FileSystem exists:bundlePath])
             {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    [Utilities alert:@"Failed to load Unbound's bundle. Please report "
-                                     @"this to the developers."];
+                    [Utilities alert:@"Bundle failed to download, please report this "
+                                     @"to the developers."];
                 });
             }
+            else
+            {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [Utilities alert:@"Bundle failed to update, loading out of date bundle."];
+                });
+            }
+        }
 
-            dispatch_semaphore_signal(gUnboundBundleSem);
-        });
+        // A newer load started while we were downloading - let it win.
+        if (token != gPrefetchToken)
+        {
+            return;
+        }
+
+        if ([FileSystem exists:bundlePath])
+        {
+            NSData *bundle = [FileSystem readFile:bundlePath];
+            if (bundle.length)
+            {
+                gUnboundBundle = bundle;
+            }
+        }
+
+        if (!gUnboundBundle)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [Utilities alert:@"Failed to load Unbound's bundle. Please report "
+                                 @"this to the developers."];
+            });
+        }
+
+        dispatch_semaphore_signal(gUnboundBundleSem);
     });
 }
 
 // Waits on a background queue so the prefetch wait never blocks the JS thread.
 static void enqueueUnboundBundle(RCTInstance *self)
 {
-    static dispatch_once_t once;
-    dispatch_once(&once, ^{
-        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-            if (gUnboundBundleSem)
-            {
-                dispatch_semaphore_wait(gUnboundBundleSem, DISPATCH_TIME_FOREVER);
-            }
+    // Snapshot this load's semaphore so a reload that swaps gUnboundBundleSem mid-wait
+    // can't make us wait on the wrong one.
+    dispatch_semaphore_t sem = gUnboundBundleSem;
 
-            NSData *bundle = gUnboundBundle;
-            if (bundle.length == 0)
-            {
-                return;
-            }
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        if (sem)
+        {
+            dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+        }
 
+        NSData *bundle = gUnboundBundle;
+        if (bundle.length == 0)
+        {
+            return;
+        }
+
+        [Logger info:LOG_CATEGORY_DEFAULT
+              format:@"Scheduling Unbound's bundle for execution..."];
+        [self callFunctionOnBufferedRuntimeExecutor:[bundle](jsi::Runtime &runtime) {
+            [Logger info:LOG_CATEGORY_DEFAULT format:@"Attempting to execute bundle..."];
+            [JSI evaluate:bundle tag:@"unbound" runtime:runtime];
             [Logger info:LOG_CATEGORY_DEFAULT
-                  format:@"Scheduling Unbound's bundle for execution..."];
-            [self callFunctionOnBufferedRuntimeExecutor:[bundle](jsi::Runtime &runtime) {
-                [Logger info:LOG_CATEGORY_DEFAULT format:@"Attempting to execute bundle..."];
-                [JSI evaluate:bundle tag:@"unbound" runtime:runtime];
-                [Logger info:LOG_CATEGORY_DEFAULT
-                      format:@"Unbound's bundle was successfully executed."];
-            }];
-        });
+                  format:@"Unbound's bundle was successfully executed."];
+        }];
     });
 }
 
@@ -187,6 +200,10 @@ static void enqueueUnboundBundle(RCTInstance *self)
     [Fonts init];
 
     prefetchUnboundBundle();
+
+    // Opt-in dev live reload; no-op unless `loader.update.hmr` is enabled.
+    [HotReload observe];
+
     %orig(sourceURL);
 }
 


### PR DESCRIPTION
## Summary

Adds an **opt-in hot-reload (HMR)** path so editing JS in the dev client reloads the running app automatically. Gated behind the `loader.update.hmr` setting (off by default) and toggled **live** — flipping the setting starts/stops the stream without relaunching.

> Requires the matching SSE dev-server change in the client repo (`/__hot` Server-Sent Events + `ETag` on the served bundle). This PR is the loader/native half.

## What's included

- **`HotReload`** (new): an `NSURLSession`-based SSE client that streams the dev server's `/__hot` endpoint (origin derived from `loader.update.url`). On an etag mismatch it calls `[Utilities reloadApp]`; reconnects with capped backoff. No special-casing for prod — against the default GitHub raw URL it just retries quietly.
- **`Settings`**: posts `UnboundSettingsDidChangeNotification` whenever `settings.json` changes, so features can react to live setting toggles. `HotReload` observes it to start/stop instantly.
- **`Unbound.xm`**: the bundle prefetch/enqueue now runs **per bundle load** instead of once per process, so a reload actually re-fetches and re-evaluates the bundle. `gPrefetchToken` discards a download from a load that was superseded by a newer one.
- **`FileSystem`**: the file monitor is reworked into typed `FileMonitor` / `DirectoryWatcher` models with a **shared per-directory** vnode watcher. This catches every write style — in-place writes, atomic write-temp+rename, and delete+recreate — and re-arms the per-file source across inode swaps. Duplicate directory watchers are de-duplicated (one source per parent dir, fanned out to all files under it).

## Testing

Smoke-tested on a virtual device:

- **FileSystem monitor** — all write styles fire exactly once each (debounced): in-place rewrite, atomic rename, delete+recreate, in-place-after-replace (re-arm proof), `cp -f`, `touch`.
- **HMR live toggle** — flipping `loader.update.hmr` false→true was detected live; the loader picked up the new value with no relaunch.
- **SSE client** — enabling HMR opened a persistent connection from the device to the dev server's `/__hot`; disabling tore it down.
- **Live reload** — touching a JS source triggered the device to reload and re-fetch the new bundle, then reconnect.

## Notes

- `loader.update.hmr` is **off by default**; production behaviour is unchanged.
- `.vscode/build-actions.sh`: `scp -O` (legacy protocol) for the vphone install target.
- `README.md`: documents the contributor HMR workflow.