### PR TITLE
feat(tooling): vphone SSH skill + MCP server

### DIFF
--- a/.claude/mcp/vphone/.gitignore
+++ b/.claude/mcp/vphone/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+bun.lock
+bun.lockb

--- a/.claude/mcp/vphone/lib.mjs
+++ b/.claude/mcp/vphone/lib.mjs
@@ -1,0 +1,59 @@
+import { execFile } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// .claude/mcp/vphone/lib.mjs -> repo root is three levels up.
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+/** Absolute paths to the shell scripts the tools delegate to (single source of truth for device quirks). */
+export const SCRIPTS = {
+	vphone: resolve(ROOT, '.claude/skills/vphone/scripts/vphone.sh'),
+	logs: resolve(ROOT, '.claude/skills/vphone/scripts/vphone-logs.sh'),
+};
+
+/**
+ * Run an executable and resolve with its trimmed stdout.
+ * @param {string} bin Absolute path to the executable.
+ * @param {string[]} args Arguments to pass.
+ * @param {{ timeoutMs?: number }} [opts] Optional kill timeout in milliseconds.
+ * @returns {Promise<string>} Trimmed stdout; rejects with stderr (or the spawn error) on non-zero exit.
+ */
+export const exec = (bin, args, { timeoutMs } = {}) =>
+	new Promise((res, rej) =>
+		execFile(
+			bin,
+			args,
+			{ env: process.env, maxBuffer: 32 << 20, timeout: timeoutMs },
+			(err, out, errOut) =>
+				err ? rej(new Error(errOut?.trim() || err.message)) : res(out.trim()),
+		),
+	);
+
+/** Run the `vphone.sh` wrapper with the given subcommand args. @param {string[]} args @returns {Promise<string>} */
+export const vphone = (args) => exec(SCRIPTS.vphone, args);
+
+/** Wrap text as a successful MCP tool result. @param {string} text @returns {object} */
+export const ok = (text) => ({ content: [{ type: 'text', text: text || '(no output)' }] });
+
+/** Wrap an error as a failed MCP tool result. @param {Error} err @returns {object} */
+export const fail = (err) => ({
+	content: [{ type: 'text', text: `Error: ${err.message}` }],
+	isError: true,
+});
+
+/**
+ * Register a tool whose handler resolves to a string, folding the try/ok/fail boilerplate into one place.
+ * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server
+ * @param {string} name Tool name.
+ * @param {string} description Human/LLM-facing description.
+ * @param {Record<string, import('zod').ZodTypeAny>} schema Zod input schema (use {} for no args).
+ * @param {(args: object) => Promise<string>} handler Returns the text payload; thrown errors become tool errors.
+ */
+export const define = (server, name, description, schema, handler) =>
+	server.tool(name, description, schema, async (args) => {
+		try {
+			return ok(await handler(args));
+		} catch (err) {
+			return fail(err);
+		}
+	});

--- a/.claude/mcp/vphone/package.json
+++ b/.claude/mcp/vphone/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "vphone-mcp",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "MCP server for interacting with the virtual iPhone (vphone) over SSH.",
+  "bin": { "vphone-mcp": "server.mjs" },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  }
+}

--- a/.claude/mcp/vphone/server.mjs
+++ b/.claude/mcp/vphone/server.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+/**
+ * vphone MCP server — exposes the virtual iPhone (vphone) tooling as MCP tools.
+ *
+ * Every tool delegates to the shell scripts under `.claude/skills/vphone/scripts/`,
+ * keeping a single source of truth for the device's quirks (scp -O, password sudo,
+ * jq settings merges, the logarchive→ndjson log pipeline). The connection is
+ * configured via env on the wrapper: VPHONE_HOST, VPHONE_PORT, VPHONE_USER, VPHONE_PASS.
+ */
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import { SCRIPTS, define, exec, vphone } from './lib.mjs';
+
+const DISCORD = 'com.hammerandchisel.discord';
+const server = new McpServer({ name: 'vphone', version: '1.0.0' });
+
+define(server, 'vphone_ping', 'Check whether the virtual iPhone is reachable over SSH.', {}, () =>
+	vphone(['ping']),
+);
+
+define(
+	server,
+	'vphone_ssh',
+	'Run a shell command on the vphone (non-root).',
+	{
+		command: z.string().describe('Command to run on the device, e.g. "ls /var/mobile".'),
+	},
+	({ command }) => vphone(['ssh', 'sh', '-c', command]),
+);
+
+define(
+	server,
+	'vphone_sudo',
+	'Run a shell command on the vphone as root.',
+	{
+		command: z
+			.string()
+			.describe('Command to run as root, e.g. "cat /var/mobile/.../settings.json".'),
+	},
+	({ command }) => vphone(['sudo', command]),
+);
+
+define(
+	server,
+	'vphone_push',
+	'Copy a file from the host to the vphone (uses scp -O).',
+	{
+		local: z.string().describe('Local source path.'),
+		remote: z.string().describe('Remote destination path on the device.'),
+	},
+	({ local, remote }) =>
+		vphone(['push', local, remote]).then(() => `pushed ${local} -> ${remote}`),
+);
+
+define(
+	server,
+	'vphone_pull',
+	'Copy a file from the vphone to the host (uses scp -O).',
+	{
+		remote: z.string().describe('Remote source path on the device.'),
+		local: z.string().describe('Local destination path.'),
+	},
+	({ remote, local }) =>
+		vphone(['pull', remote, local]).then(() => `pulled ${remote} -> ${local}`),
+);
+
+define(
+	server,
+	'vphone_app_data',
+	"Resolve an app's Data container path on the vphone.",
+	{
+		bundleId: z.string().optional().describe(`Bundle id (default ${DISCORD}).`),
+	},
+	({ bundleId }) => vphone(bundleId ? ['app-data', bundleId] : ['app-data']),
+);
+
+define(
+	server,
+	'vphone_unbound_dir',
+	'Print the Unbound directory path on the vphone (holds settings.json, unbound.js, Plugins/Themes/Fonts/i18n).',
+	{},
+	() => vphone(['unbound-dir']),
+);
+
+define(
+	server,
+	'vphone_settings_get',
+	'Read the Unbound settings.json. Optionally apply a jq filter.',
+	{
+		filter: z.string().optional().describe('jq filter, e.g. ".unbound.loader.update.hmr".'),
+	},
+	({ filter }) => vphone(filter ? ['settings-get', filter] : ['settings-get']),
+);
+
+define(
+	server,
+	'vphone_settings_set',
+	'Set unbound.<key> in settings.json to a JSON value (backs up + pushes).',
+	{
+		key: z.string().describe('Dotted key under the unbound store, e.g. "loader.update.hmr".'),
+		value: z.string().describe('Raw JSON value, e.g. true, false, 42, or \'"a string"\'.'),
+	},
+	({ key, value }) => vphone(['settings-set', key, value]),
+);
+
+define(server, 'vphone_restart', 'Kill and relaunch Discord on the vphone.', {}, () =>
+	vphone(['restart']),
+);
+
+define(
+	server,
+	'vphone_logs_udid',
+	'Print the resolved vphone UDID used for log capture (the virtual iPhone, never the real device).',
+	{},
+	() => exec(SCRIPTS.logs, ['udid']),
+);
+
+define(
+	server,
+	'vphone_logs',
+	'Snapshot structured, timestamped Unbound logs from the vphone. Reads os_log via logarchive+ndjson (no syslog regex) and emits clean "HH:MM:SS.mmm L [category|JS] message" lines from BOTH native (subsystem app.unbound) and JS/React Native console (subsystem com.facebook.react.log), all levels incl. debug/info. To capture exactly one action (e.g. a restart): note the current UNIX time (`date +%s`) BEFORE the action, run the action (vphone_restart), then pass that value as `since` — windows to precisely that boot instead of dumping history. Otherwise pass `seconds` for a relative look-back.',
+	{
+		since: z
+			.number()
+			.int()
+			.optional()
+			.describe(
+				'Absolute UNIX timestamp to start from (capture `date +%s` BEFORE the action). Takes precedence over seconds; gives an exact window.',
+			),
+		seconds: z
+			.number()
+			.int()
+			.min(1)
+			.max(600)
+			.optional()
+			.describe(
+				'Relative look-back window in seconds (default 30). Ignored if `since` is set.',
+			),
+		filter: z
+			.string()
+			.optional()
+			.describe(
+				'Optional case-insensitive fixed-string filter the line must contain, e.g. "[JS]", "updater", " E [".',
+			),
+	},
+	({ since, seconds, filter }) => {
+		// `since` -> exact window from an absolute time; otherwise a relative look-back.
+		const [mode, value] = since != null ? ['since', since] : ['show', seconds ?? 30];
+		const args = [mode, String(value), ...(filter ? [filter] : [])];
+		// Budget: cover the whole window plus archive-pull overhead.
+		const windowSecs = since != null ? Math.floor(Date.now() / 1000) - since : value;
+		return exec(SCRIPTS.logs, args, { timeoutMs: (Math.max(windowSecs, 30) + 30) * 1000 });
+	},
+);
+
+await server.connect(new StdioServerTransport());

--- a/.claude/skills/vphone/SKILL.md
+++ b/.claude/skills/vphone/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: vphone
+description: Use when interacting with the virtual iPhone (vphone) over SSH — running commands on the device, copying files to/from it, reading or changing Unbound loader settings (e.g. loader.update.hmr), finding an app's data container, restarting Discord, or monitoring/catting Unbound logs (native os_log + JS/React Native console, timestamped). Covers the dropbear "no sftp-server"/scp -O gotcha, password sudo, and the host-side idevicesyslog log path on the jailbroken iOS VM.
+---
+
+# vphone (Virtual iPhone over SSH)
+
+## Overview
+
+The **vphone** is a jailbroken iOS VM running Discord + the Unbound loader, used to test this tweak. You reach it over SSH and manage it with the wrapper at `scripts/vphone.sh`. Prefer the wrapper over raw `ssh`/`scp` — it encodes the device's quirks.
+
+Connection (defaults, override via env): `mobile@127.0.0.1:2222`, password `alpine`.
+
+## Critical gotchas (why use the wrapper)
+
+- **No sftp-server.** dropbear lacks it, so plain `scp` fails with `/usr/libexec/sftp-server: No such file`. **Always use `scp -O`** (legacy rcp protocol). The wrapper does this.
+- **Password sudo.** Root needs `echo 'alpine' | sudo -S …`. The wrapper's `sudo` subcommand handles it.
+- **No python on device.** Don't edit JSON in place on the phone. Pull → edit host-side with `jq` → push back. The wrapper's `settings-set` does exactly this (with a `.bak` backup).
+- **Unbound settings live at** `…/Documents/Unbound/settings.json` in Discord's *Data* container, under the `unbound` store. Keys are dotted, e.g. `loader.update.hmr`, `loader.update.url`.
+
+## Where things live on the device
+
+Everything Unbound owns sits in Discord's **Data** container (the per-install, writable one — *not* the read-only `.app` Bundle container):
+
+```
+/var/mobile/Containers/Data/Application/<UUID>/Documents/Unbound/
+├── settings.json     # all settings, under stores "unbound" and "unbound::cache"
+├── settings.json.bak # backup written by `settings-set`
+├── unbound.js        # the downloaded JS bundle the loader injects
+├── Fonts/            # installed custom fonts
+├── Plugins/          # installed plugins
+├── Themes/           # installed themes
+└── i18n/             # localisation data
+```
+
+The `<UUID>` changes per install/reinstall, so **never hardcode it** — resolve it:
+
+```bash
+$S app-data                 # Discord's Data container root
+$S settings-path            # full path to settings.json
+$S sudo "ls -la $(\$S app-data)/Documents/Unbound"
+```
+
+`app-data` matches the bundle id (default `com.hammerandchisel.discord`) against each container's `.com.apple.mobile_container_manager.metadata.plist`. Reading any of these paths needs **root** (`sudo`), since they're under `/var/mobile/Containers`.
+
+> The system Application *Bundle* (the installed `.app`, the tweak `.dylib`, etc.) lives under a different tree: `/var/containers/Bundle/Application/<UUID>/`. That's the code; `Documents/Unbound/` above is the data.
+
+## Quick Reference
+
+Run from the loader repo root. `S=.claude/skills/vphone/scripts/vphone.sh`
+
+| Goal | Command |
+|------|---------|
+| Check reachable | `$S ping` |
+| Run a command | `$S ssh <cmd…>` |
+| Run as root | `$S sudo <cmd…>` |
+| Copy to device | `$S push <local> <remote>` |
+| Copy from device | `$S pull <remote> <local>` |
+| App data container | `$S app-data [bundleid]` (default Discord) |
+| Unbound directory | `$S unbound-dir` |
+| Settings file path | `$S settings-path` |
+| Read settings | `$S settings-get [<jq-filter>]` |
+| Change a setting | `$S settings-set <dot.key> <json>` |
+| Restart Discord | `$S restart` |
+| Stream logs (live) | `$L stream [filter]` |
+| Snapshot logs (relative) | `$L show [secs] [filter]` |
+| Snapshot logs (since time) | `$L since <unixts> [filter]` |
+
+`settings-set` value is **raw JSON**: `true`, `false`, `42`, `'"some string"'`.
+
+`$L` = `.claude/skills/vphone/scripts/vphone-logs.sh`.
+
+## Common tasks
+
+**Toggle HMR (live reload):**
+```bash
+$S settings-set loader.update.hmr true     # HotReload picks it up live (no relaunch)
+$S settings-get .unbound.loader.update.hmr
+```
+
+**Point the loader at a dev server:**
+```bash
+$S settings-set loader.update.url '"http://192.168.64.1:3000/"'
+```
+
+**Inspect the whole settings file:**
+```bash
+$S settings-get | jq '.unbound.loader'
+```
+
+## Logs
+
+Unbound logs via **`os_log`**. There is **no on-device `log` binary** (zsh's `log` is a builtin), so we read os_log **host-side** with the structured pipeline in `scripts/vphone-logs.sh` (`$L`): `idevicesyslog` pulls a `.logarchive` from the device → the host's `/usr/bin/log` renders it as **NDJSON** → `format-logs.jq` turns each event into a clean line. **No syslog-line regex** — every field (time, level, subsystem, category, message) comes typed from JSON.
+
+Output format: `HH:MM:SS.mmm  L  [category|JS]  message`
+
+Two Unbound sources are selected by **subsystem** and interleaved chronologically:
+
+- **Native** (`Logger.m`): `subsystem == "app.unbound"` → `[category] msg` (category = `updater`, `themes`, `default`, …)
+- **JS / React Native** (`console.*`): `subsystem == "com.facebook.react.log"` → `[JS] msg` (jq strips ANSI and unwraps the `'»', …` console arg-list)
+
+**Levels:** `--info --debug` are always passed. RN tags every JS line as `Info` but the log store still gates info/debug behind those flags — without them ~all JS lines vanish. Level is never filtered, so **debug + release** both surface.
+
+```bash
+$L stream                 # live tail (native + JS), Ctrl-C — polls every ~2s
+$L stream updater         # live, fixed-string filter (case-insensitive)
+$L show 30                # snapshot last 30s (relative look-back)
+$L show 30 '[JS]'         # snapshot, JS only
+$L since 1782529286       # snapshot from an absolute UNIX timestamp (exact window)
+$L json 30                # raw Unbound NDJSON, for piping into your own jq
+$L udid                   # the resolved vphone UDID
+```
+
+**Scope logs to one action** (avoids dumping minutes of history): grab the time with plain `date +%s`, do the action, then `since`:
+
+```bash
+T=$(date +%s); $S restart; $L since "$T"   # exactly this boot, nothing earlier
+```
+
+Relative `show`/`json` use `idevicesyslog --age-limit`, which over-fetches; `since` uses `--start-time` plus a `log show --start` trim for an exact lower bound.
+
+> **Live = poll.** Host `log stream` can't target a remote device and `idevicesyslog` has no structured output, so `stream` pulls a short logarchive every ~2s (set `VPHONE_LOG_INTERVAL`) and dedups by `machTimestamp` — clean structured lines at ~2s latency, not instant. `show`/`json` look back over a fixed window (no historical playback beyond what's still in the device's log store).
+>
+> **Safety:** two devices are usually paired — the throwaway **vphone** *and a real iPhone*. `$L` resolves the vphone by ProductType `iPhone99,11` and **never** falls back to the real device. Override with `VPHONE_UDID`.
+
+## MCP alternative
+
+An MCP server exposing these same operations as tools lives in `.claude/mcp/vphone/` and is wired up in the repo's `.mcp.json`: `vphone_ping`, `vphone_ssh`, `vphone_sudo`, `vphone_push`, `vphone_pull`, `vphone_app_data`, `vphone_unbound_dir`, `vphone_settings_get`, `vphone_settings_set`, `vphone_restart`, `vphone_logs` (structured native+JS snapshot; accepts `since` for an exact window or `seconds` for relative), `vphone_logs_udid`. Use the MCP tools when available; they call the same scripts underneath. (Live `stream` is shell-only — MCP exposes the bounded `vphone_logs` snapshot.)
+
+**Combo pattern (scope logs to one action):** grab `date +%s` on the host → `vphone_restart` → `vphone_logs({ since })`. Captures exactly that boot, not history.
+
+## Common Mistakes
+
+- Using plain `scp` → sftp error. Use the wrapper (`push`/`pull`) or `scp -O`.
+- Editing `settings.json` with `sed` for anything non-trivial → risk corrupting the 38KB file (it also holds `unbound::cache`). Use `settings-set` (jq merge + backup).
+- Passing a bare string to `settings-set` → invalid JSON. Quote it: `'"value"'`.
+- Forgetting `sudo` — most device paths under `/var/mobile/Containers` need root to read.

--- a/.claude/skills/vphone/scripts/format-logs.jq
+++ b/.claude/skills/vphone/scripts/format-logs.jq
@@ -1,0 +1,57 @@
+# format-logs.jq — turn `log show --style ndjson` events into clean, readable lines.
+#
+# Input: one JSON log event per line (NDJSON), as produced by:
+#   /usr/bin/log show --archive A --predicate '...' --info --debug --style ndjson
+#
+# Two Unbound sources are handled:
+#   app.unbound            -> native os_log; eventMessage = "[Unbound] [Cat] msg"
+#   com.facebook.react.log -> JS console; eventMessage = "'>>', '<ansi>[Scope]<ansi>', '<ansi>msg<ansi>'"
+#
+# We never parse the syslog text line: every field (time, level, subsystem,
+# category, message) comes typed from the JSON. Cleanup (on the message STRING
+# only) = ANSI removal, unwrapping the JS console arg-list, collapsing multi-line
+# messages, and dropping a leading "[Category]" bracket ONLY when it duplicates
+# the category column. A leading bracket that differs from the category (e.g. a
+# "[Debugger]" message logged under category "default") is real content and kept.
+#
+# Output:  HH:MM:SS.mmm  L  [category|JS]  message
+
+# Strip ANSI colour escapes: both the raw ESC-byte form and the literal
+# "[..m" text form React Native serialises into the message.
+def deansi:
+  gsub("\\[[0-9;]*m"; "")
+  | gsub("\\\\u001b\\[[0-9;]*m"; "");
+
+# Keep each event on one line (native NSError dumps embed newlines).
+def oneline:
+  gsub("\\s*\n\\s*"; " ") | gsub("  +"; " ");
+
+# Unwrap the JS console arg-list "'a', 'b', 'c'" -> "a b c" (after deansi).
+# RN joins console.* args as single-quoted, comma-separated tokens; the first is
+# the leading marker arg, which we drop.
+def unwrap_js:
+  deansi
+  | sub("^'[^']*', "; "")     # drop the leading marker token ('>>')
+  | ltrimstr("'") | rtrimstr("'")
+  | gsub("', '"; " ")
+  | oneline;
+
+# Native messages are "[Unbound] [Category] msg". Drop the "[Unbound] " tag, and
+# drop the leading "[Category] " bracket ONLY when it duplicates the os_log
+# category column (case-insensitive). A leading bracket that does NOT match the
+# category is real content and is preserved.
+def native_msg($cat):
+  (deansi | ltrimstr("[Unbound] ") | oneline) as $m
+  | ($m | capture("^\\[(?<b>[A-Za-z]+)\\] (?<rest>.*)$") // null) as $cap
+  | (if $cap != null and ($cap.b | ascii_downcase) == ($cat | ascii_downcase)
+        then $cap.rest else $m end);
+
+(.timestamp[11:23] // "??:??:??.???") as $t
+| ((.messageType // "Default")[0:1]) as $lvl
+| (.eventMessage // "") as $msg
+| (.category // "default") as $cat
+| if .subsystem == "com.facebook.react.log"
+    then "\($t) \($lvl) [JS] \($msg | unwrap_js)"
+  else
+    "\($t) \($lvl) [\($cat)] \($msg | native_msg($cat))"
+  end

--- a/.claude/skills/vphone/scripts/vphone-logs.sh
+++ b/.claude/skills/vphone/scripts/vphone-logs.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# vphone-logs.sh — structured, timestamped Unbound logs from the virtual iPhone.
+#
+# Unbound logs via os_log. There is NO on-device `log` binary, so we read os_log
+# HOST-side: idevicesyslog pulls a `.logarchive` from the device, and the host's
+# /usr/bin/log renders it as NDJSON (one JSON event per line). We then pick the
+# two Unbound sources by SUBSYSTEM (no syslog-line regex):
+#
+#   app.unbound             → native os_log (Logger.m)
+#   com.facebook.react.log  → JS / React Native console.* (category "javascript")
+#
+# Every field (timestamp, level, subsystem, category, message) comes typed from
+# the JSON; format-logs.jq turns each event into a clean line. The ONLY string
+# cleanup is ANSI removal + unwrapping the JS console arg-list, done by jq on the
+# message field — never on the whole log line.
+#
+# LEVELS: --info --debug are REQUIRED. RN logs everything at "Info" type, but the
+# unified-logging store still gates Info/Debug events behind these flags; without
+# them ~all JS (and most native) lines vanish. We never filter by level.
+#
+# Live `stream` = poll: pull a short archive every INTERVAL seconds and emit only
+# events newer than the last one seen (dedup by machTimestamp). Host `log stream`
+# can't target a remote device, and idevicesyslog has no structured output, so
+# polling is how we keep the clean ndjson pipeline live (~INTERVAL latency).
+#
+# SAFETY: two devices are usually paired — the throwaway vphone AND a real iPhone.
+# We resolve the vphone by ProductType iPhone99,11 and NEVER fall back to the real
+# device. Override with VPHONE_UDID.
+#
+# Usage:
+#   vphone-logs.sh show [seconds] [grep]   # snapshot last N seconds (default 30)
+#   vphone-logs.sh since <unixts> [grep]   # snapshot from an absolute UNIX time
+#   vphone-logs.sh stream [grep]           # live tail (Ctrl-C to stop)
+#   vphone-logs.sh udid                    # print resolved vphone UDID
+#   vphone-logs.sh json [seconds]          # raw Unbound NDJSON (for piping)
+#
+#   [grep] is an optional case-insensitive substring the formatted line must
+#   contain, e.g. "updater" or "[JS]".
+#
+# Pin a window to an action: grab the time, do the action, then `since`:
+#   T=$(date +%s); vphone.sh restart; vphone-logs.sh since "$T"
+#
+# Env: VPHONE_UDID (override), VPHONE_LOG_INTERVAL (stream poll seconds, default 2).
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JQ_FMT="$HERE/format-logs.jq"
+VPHONE_PRODUCT="iPhone99,11"
+PREDICATE='subsystem == "app.unbound" OR subsystem == "com.facebook.react.log"'
+INTERVAL="${VPHONE_LOG_INTERVAL:-2}"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "$1 not found (brew install $2)" >&2; exit 1; }; }
+need idevicesyslog libimobiledevice
+need jq jq
+[ -x /usr/bin/log ] || { echo "/usr/bin/log (macOS unified logging) not found" >&2; exit 1; }
+
+resolve_udid() {
+  if [ -n "${VPHONE_UDID:-}" ]; then echo "$VPHONE_UDID"; return; fi
+  need idevice_id libimobiledevice; need ideviceinfo libimobiledevice
+  local match=""
+  while IFS= read -r udid; do
+    [ -n "$udid" ] || continue
+    if [ "$(ideviceinfo -u "$udid" -k ProductType 2>/dev/null || true)" = "$VPHONE_PRODUCT" ]; then
+      [ -z "$match" ] && match="$udid" || { echo "multiple vphone candidates; set VPHONE_UDID" >&2; exit 1; }
+    fi
+  done < <(idevice_id -l 2>/dev/null)
+  [ -n "$match" ] || { echo "vphone ($VPHONE_PRODUCT) not found; set VPHONE_UDID" >&2; exit 1; }
+  echo "$match"
+}
+
+# Emit Unbound NDJSON for device $2, windowed by spec $1:
+#   age:<secs>     -> last <secs> seconds (idevicesyslog --age-limit)
+#   since:<unixts> -> from absolute UNIX timestamp (idevicesyslog --start-time),
+#                     plus an exact post-filter so nothing older than <unixts>
+#                     leaks in (the archive over-fetches around the boundary).
+# The window is anchored at PULL time; events are sorted by machTimestamp.
+pull_ndjson() {
+  local spec="$1" udid="$2"
+  local tmp; tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  local kind="${spec%%:*}" val="${spec#*:}" start_pred=""
+  case "$kind" in
+    since)
+      idevicesyslog -u "$udid" archive "$tmp/a.tar" --start-time "$val" >/dev/null 2>&1 || return 0
+      # `log show --start` takes a local "YYYY-MM-DD HH:MM:SS" — exact post-trim
+      # in case the archive over-fetches around the boundary.
+      start_pred="$(date -r "$val" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || true)" ;;
+    age|*)
+      [ "$kind" = age ] || val="$spec"   # bare number => treat as age seconds
+      idevicesyslog -u "$udid" archive "$tmp/a.tar" --age-limit "$val" >/dev/null 2>&1 || return 0 ;;
+  esac
+
+  # The tar IS a logarchive's contents (Info.plist, *.tracev3, Persist/, …), but
+  # `log` requires the directory name to end in `.logarchive`, so extract there.
+  mkdir -p "$tmp/d.logarchive"
+  tar -xf "$tmp/a.tar" -C "$tmp/d.logarchive" 2>/dev/null || return 0
+  local show_args=(--archive "$tmp/d.logarchive" --predicate "$PREDICATE" --info --debug --style ndjson)
+  [ -n "$start_pred" ] && show_args+=(--start "$start_pred")
+  /usr/bin/log show "${show_args[@]}" 2>/dev/null \
+    | jq -rR 'fromjson? // empty' 2>/dev/null || true
+}
+
+# NDJSON (stdin) -> clean formatted lines, with optional case-insensitive
+# FIXED-STRING filter (so "[JS]" matches literally, not as a regex class).
+format() {
+  local extra="${1:-}"
+  if [ -n "$extra" ]; then
+    jq -rcf "$JQ_FMT" 2>/dev/null | grep -iF --line-buffered -e "$extra"
+  else
+    jq -rcf "$JQ_FMT" 2>/dev/null
+  fi
+}
+
+case "${1:-stream}" in
+  udid) resolve_udid ;;
+
+  json)
+    UDID="$(resolve_udid)"; SECS="${2:-30}"
+    pull_ndjson "age:$SECS" "$UDID" ;;
+
+  show)
+    UDID="$(resolve_udid)"; SECS="${2:-30}"; EXTRA="${3:-}"
+    echo ">> last ${SECS}s from vphone $UDID (native app.unbound + JS com.facebook.react.log, all levels)" >&2
+    pull_ndjson "age:$SECS" "$UDID" | format "$EXTRA" ;;
+
+  since)
+    UDID="$(resolve_udid)"; TS="${2:?since requires a UNIX timestamp (see: $0 now)}"; EXTRA="${3:-}"
+    echo ">> since $(date -r "$TS" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "$TS") from vphone $UDID (native + JS, all levels)" >&2
+    pull_ndjson "since:$TS" "$UDID" | format "$EXTRA" ;;
+
+  stream)
+    UDID="$(resolve_udid)"; EXTRA="${2:-}"
+    echo ">> streaming vphone $UDID (poll ${INTERVAL}s, native + JS, all levels) — Ctrl-C to stop" >&2
+    win="$(mktemp)"; trap 'rm -f "$win"' EXIT
+    last=0
+    while :; do
+      # One pull per round, reused twice: print events newer than `last`, then
+      # advance `last` to the newest machTimestamp in this window (dedup).
+      pull_ndjson "$((INTERVAL + 3))" "$UDID" > "$win" || true
+      jq -rc --argjson last "$last" 'select((.machTimestamp // 0) > $last)' < "$win" | format "$EXTRA"
+      newest="$(jq -rs 'map(.machTimestamp // 0) | max // 0 | floor' < "$win" 2>/dev/null || echo 0)"
+      [ "${newest:-0}" -gt "$last" ] 2>/dev/null && last="$newest"
+      sleep "$INTERVAL"
+    done ;;
+
+  *)
+    sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1 ;;
+esac

--- a/.claude/skills/vphone/scripts/vphone.sh
+++ b/.claude/skills/vphone/scripts/vphone.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# vphone.sh — thin wrapper around the virtual iPhone (vphone) reachable over SSH.
+#
+# The vphone is a jailbroken iOS VM running Discord + the Unbound loader. Its
+# dropbear sshd has NO sftp-server, so file copies MUST use `scp -O` (legacy
+# rcp protocol). `sudo` is password-based (`sudo -S`). There is no python on the
+# device, so JSON edits are done host-side and pushed back.
+#
+# Connection (overridable via env):
+#   VPHONE_HOST=127.0.0.1  VPHONE_PORT=2222  VPHONE_USER=mobile  VPHONE_PASS=alpine
+#
+# Usage:
+#   vphone.sh ping                          # check reachability
+#   vphone.sh ssh   <cmd...>                # run a command (no sudo)
+#   vphone.sh sudo  <cmd...>                # run a command as root
+#   vphone.sh push  <local> <remote>        # copy host -> device (scp -O)
+#   vphone.sh pull  <remote> <local>        # copy device -> host (scp -O)
+#   vphone.sh app-data <bundleid>           # print app Data container path
+#   vphone.sh unbound-dir                   # print the Unbound directory path
+#   vphone.sh settings-path                 # print Unbound settings.json path
+#   vphone.sh settings-get [<jq-filter>]    # cat Unbound settings.json (host jq optional)
+#   vphone.sh settings-set <dot.key> <json> # set unbound.<dot.key> = <json>, backup + push
+#   vphone.sh restart                       # kill & relaunch Discord
+#
+set -euo pipefail
+
+VPHONE_HOST="${VPHONE_HOST:-127.0.0.1}"
+VPHONE_PORT="${VPHONE_PORT:-2222}"
+VPHONE_USER="${VPHONE_USER:-mobile}"
+VPHONE_PASS="${VPHONE_PASS:-alpine}"
+DISCORD_BID="com.hammerandchisel.discord"
+
+SSH_BASE=(-p "$VPHONE_PORT" -o ConnectTimeout=8 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
+TARGET="${VPHONE_USER}@${VPHONE_HOST}"
+
+need_sshpass() {
+  command -v sshpass >/dev/null 2>&1 || { echo "sshpass not found (brew install sshpass)" >&2; exit 1; }
+}
+
+_ssh()  { need_sshpass; sshpass -p "$VPHONE_PASS" ssh "${SSH_BASE[@]}" "$TARGET" "$@"; }
+# scp -O forces legacy protocol; modern scp defaults to sftp which dropbear lacks.
+_scp()  { need_sshpass; sshpass -p "$VPHONE_PASS" scp -O -P "$VPHONE_PORT" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"; }
+_sudo() { need_sshpass; sshpass -p "$VPHONE_PASS" ssh "${SSH_BASE[@]}" "$TARGET" "echo '$VPHONE_PASS' | sudo -S sh -c \"$*\" 2>/dev/null"; }
+
+app_data() {
+  local bid="${1:?bundle id required}"
+  _sudo "find /var/mobile/Containers/Data/Application -maxdepth 4 -name '.com.apple.mobile_container_manager.metadata.plist' -exec grep -l '$bid' {} +" \
+    | sed 's#/\.com\.apple\.mobile_container_manager\.metadata\.plist##' | head -n1
+}
+
+unbound_dir() {
+  local p; p="$(settings_path)"
+  [ -n "$p" ] && dirname "$p"
+}
+
+settings_path() {
+  # Unbound writes to Documents/Unbound/settings.json in the Discord data container.
+  _sudo "find /var/mobile/Containers/Data/Application -maxdepth 5 -path '*Documents/Unbound/settings.json'" | head -n1
+}
+
+case "${1:-}" in
+  ping)
+    if _ssh "exit" >/dev/null 2>&1; then echo "vphone reachable ($TARGET:$VPHONE_PORT)"; else echo "vphone UNREACHABLE ($TARGET:$VPHONE_PORT)" >&2; exit 1; fi ;;
+
+  ssh)   shift; _ssh "$@" ;;
+  sudo)  shift; _sudo "$*" ;;
+  push)  shift; _scp "${1:?local}" "$TARGET:${2:?remote}" ;;
+  pull)  shift; _scp "$TARGET:${1:?remote}" "${2:?local}" ;;
+
+  app-data)      shift; app_data "${1:-$DISCORD_BID}" ;;
+  unbound-dir)   unbound_dir ;;
+  settings-path) settings_path ;;
+
+  settings-get)
+    shift
+    p="$(settings_path)"; [ -n "$p" ] || { echo "settings.json not found" >&2; exit 1; }
+    if [ -n "${1:-}" ] && command -v jq >/dev/null 2>&1; then
+      _sudo "cat '$p'" | jq "$1"
+    else
+      _sudo "cat '$p'"
+    fi ;;
+
+  settings-set)
+    shift
+    key="${1:?dot.key required (e.g. loader.update.hmr)}"; val="${2:?json value required (e.g. true)}"
+    command -v jq >/dev/null 2>&1 || { echo "jq required on host for settings-set" >&2; exit 1; }
+    p="$(settings_path)"; [ -n "$p" ] || { echo "settings.json not found" >&2; exit 1; }
+    tmp="$(mktemp)"; out="$(mktemp)"
+    _sudo "cat '$p'" > "$tmp"
+    # Merge under the "unbound" store using a dotted path -> nested object.
+    jq --arg k "$key" --argjson v "$val" '
+      ($k | split(".")) as $path
+      | .unbound = (.unbound // {})
+      | .unbound |= setpath($path; $v)
+    ' "$tmp" > "$out"
+    _sudo "cp '$p' '$p.bak'"
+    _scp "$out" "$TARGET:/tmp/unbound-settings.json"
+    _sudo "cp /tmp/unbound-settings.json '$p' && rm -f /tmp/unbound-settings.json"
+    rm -f "$tmp" "$out"
+    echo "set unbound.$key = $val (backup at $p.bak)" ;;
+
+  restart)
+    _sudo "killall -9 Discord" || true
+    _ssh "uiopen --bundleid $DISCORD_BID"
+    echo "Discord restarted" ;;
+
+  *)
+    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1 ;;
+esac

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ packages
 venv
 patcher-ios
 private_key.pem
+.claude/worktrees

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "vphone": {
+      "command": "node",
+      "args": [".claude/mcp/vphone/server.mjs"],
+      "env": {
+        "VPHONE_HOST": "127.0.0.1",
+        "VPHONE_PORT": "2222",
+        "VPHONE_USER": "mobile",
+        "VPHONE_PASS": "alpine"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds Claude Code tooling for the virtual iPhone (vphone) dev device.

## What's included

**Skill** — `.claude/skills/vphone/`
- `vphone.sh`: `ping`/`ssh`/`sudo`/`push`/`pull`, app Data-container discovery, Unbound `settings.json` get/set (jq merge + backup), `restart`. Encodes the device quirks (dropbear has no sftp-server → `scp -O`; password `sudo`; no on-device python).
- `vphone-logs.sh` + `format-logs.jq`: structured os_log capture. There's no on-device `log` binary, so logs are read host-side via `idevicesyslog` → `.logarchive` → `/usr/bin/log ... --style ndjson` → jq. Emits clean `HH:MM:SS.mmm L [category|JS] message` lines from BOTH native (`app.unbound`) and JS/React Native console (`com.facebook.react.log`), all levels incl. debug. Supports relative `show`/live `stream` and exact `since <unixts>` windows.
- `SKILL.md` documenting all of the above + the on-device layout.

**MCP** — `.claude/mcp/vphone/`
- Modular server (`lib.mjs` helpers + declarative `server.mjs`) exposing the same operations as `vphone_*` tools. Formatted to the client's oxfmt/oxlint rules.
- `.mcp.json` wires it into the project.

## Notes
- `.claude/worktrees` is gitignored (local-only).
- `.mcp.json` carries the vphone's well-known default jailbreak password (`alpine`) for `127.0.0.1` — fine for this throwaway local VM, but flagging it.