### PR TITLE
fix(hermes): read bytecode version from shipped main.jsbundle

### DIFF
--- a/headers/HermesBytecode.h
+++ b/headers/HermesBytecode.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#import <stddef.h>
+#import <stdint.h>
+
+// Hermes bytecode (HBC) helpers for the loader.
+//
+// We need the runtime's accepted bytecode version to fetch the matching remote
+// bundle. Rather than read it out of the runtime (hidden symbols, internal C++
+// ABI), we read it from Discord's shipped HBC bundle: Discord.app/main.jsbundle is
+// compiled by the same hermesc that built the bundled hermes.framework, so its
+// header version IS the version this runtime accepts. See
+// +[Utilities getHermesBytecodeVersion].
+
+// Magic prefixing every HBC file (little-endian on disk).
+static const uint64_t HERMES_MAGIC = 0x1F1903C103BC1FC6ULL;
+
+#pragma pack(push, 1)
+typedef struct
+{
+    uint64_t magic;
+    uint32_t version;
+} HermesBytecodeFileHeaderPrefix;
+#pragma pack(pop)
+
+// YES if `data`/`length` begins with the Hermes bytecode magic.
+static inline BOOL HermesDataIsBytecode(const void *data, size_t length)
+{
+    if (!data || length < sizeof(HermesBytecodeFileHeaderPrefix))
+        return NO;
+    return ((const HermesBytecodeFileHeaderPrefix *) data)->magic == HERMES_MAGIC;
+}
+
+// Version stamped into an HBC blob (0 if it isn't HBC or is too short).
+static inline uint32_t HermesDataBytecodeVersion(const void *data, size_t length)
+{
+    if (!HermesDataIsBytecode(data, length))
+        return 0;
+    return ((const HermesBytecodeFileHeaderPrefix *) data)->version;
+}

--- a/sources/Utilities.m
+++ b/sources/Utilities.m
@@ -1,4 +1,5 @@
 #import "Utilities.h"
+#import "HermesBytecode.h"
 
 NSString *const TROLL_STORE_PATH      = @"../_TrollStore";
 NSString *const TROLL_STORE_LITE_PATH = @"../_TrollStoreLite";
@@ -509,40 +510,39 @@ static NSString *bundle = nil;
 
 + (uint32_t)getHermesBytecodeVersion
 {
-    void *symbol = dlsym(RTLD_DEFAULT, "_ZN8facebook6hermes13HermesRuntime18getBytecodeVersionEv");
-    if (!symbol)
+    // Read the accepted version from Discord's shipped HBC bundle: it's compiled by
+    // the same hermesc as the bundled hermes.framework, so its header version is the
+    // version this runtime accepts. No runtime ABI involved. See HermesBytecode.h.
+    NSString *bundlePath   = [[NSBundle mainBundle] bundlePath];
+    NSString *jsBundlePath = [bundlePath stringByAppendingPathComponent:@"main.jsbundle"];
+
+    NSFileHandle *handle = [NSFileHandle fileHandleForReadingAtPath:jsBundlePath];
+    if (!handle)
     {
-        const char *dlError = dlerror();
-        NSString   *errorMessage =
-            dlError ? [NSString stringWithUTF8String:dlError] : @"Unknown error";
         [Logger error:LOG_CATEGORY_UTILITIES
-               format:@"Failed to get bytecode version: %@", errorMessage];
+               format:@"Could not open %@ to read Hermes bytecode version", jsBundlePath];
         return 0;
     }
 
-    typedef uint32_t (*HermesBytecodeVersionFn)(void);
-    HermesBytecodeVersionFn getBytecodeVersion = (HermesBytecodeVersionFn) symbol;
+    NSData *prefix = [handle readDataOfLength:sizeof(HermesBytecodeFileHeaderPrefix)];
+    [handle closeFile];
 
-    return getBytecodeVersion ? getBytecodeVersion() : 0;
+    uint32_t version = HermesDataBytecodeVersion([prefix bytes], [prefix length]);
+    if (version == 0)
+    {
+        [Logger error:LOG_CATEGORY_UTILITIES
+               format:@"%@ is not a Hermes bytecode bundle (read %lu bytes)", jsBundlePath,
+                      (unsigned long) [prefix length]];
+        return 0;
+    }
+
+    [Logger info:LOG_CATEGORY_UTILITIES format:@"Hermes bytecode version: %u", version];
+    return version;
 }
 
 + (BOOL)isHermesBytecode:(NSData *)data
 {
-    void *symbol = dlsym(RTLD_DEFAULT, "_ZN8facebook6hermes13HermesRuntime16isHermesBytecodeEPKhm");
-    if (!symbol)
-    {
-        const char *dlError = dlerror();
-        NSString   *errorMessage =
-            dlError ? [NSString stringWithUTF8String:dlError] : @"Unknown error";
-        [Logger error:LOG_CATEGORY_UTILITIES
-               format:@"Failed to check Hermes bytecode: %@", errorMessage];
-        return NO;
-    }
-
-    typedef BOOL (*HermesIsBytecodeFn)(const uint8_t *, size_t);
-    HermesIsBytecodeFn isHermesBytecode = (HermesIsBytecodeFn) symbol;
-
-    return isHermesBytecode ? isHermesBytecode((const uint8_t *) [data bytes], [data length]) : NO;
+    return HermesDataIsBytecode([data bytes], [data length]);
 }
 
 + (BOOL)isRNNewArchEnabled


### PR DESCRIPTION
## Summary

`getHermesBytecodeVersion` used `dlsym` to resolve `facebook::hermes::HermesRuntime::getBytecodeVersion`. That symbol is the wrong class (the method is on `HermesRootAPI`, not `HermesRuntime`), and the correct symbol is hidden (`N_PEXT`) and missing from hermes.framework's dyld export trie, so `dlsym` always returned `NULL`. The method always returned `0`, so `Updater.m`'s `manifestBytecodeVersion == currentBytecodeVersion` check never matched and the Hermes bytecode bundle path was dead.

This reads the version from Discord's own shipped bundle instead. `Discord.app/main.jsbundle` is a Hermes bytecode file compiled by the same hermesc that built the bundled `hermes.framework`, so its header version is the version the runtime accepts. We open the file, read the first 12 bytes with `NSFileHandle`, and pull the version out of the HBC header. There's no `dlsym`, no vtable walking, and nothing that depends on the runtime's symbol table or memory layout.

## Why this approach

We don't control Discord's app, so anything that reverse-engineers the runtime's internals is betting on layout details Meta can change between versions. The shipped bundle and the runtime ship together in one signed app and come out of the same toolchain, so their versions stay in sync. Reading a file also can't crash or jump into the wrong code the way a stale vtable offset could.

## Behavior

Every failure path (bundle missing or renamed, short read, not actually HBC) returns `0`, and `Updater.m` falls back to the JavaScript bundle the same way it does today. On the current build the version reads as `96`.

## Testing

I haven't built or run this on device yet, since I don't have a Theos host where I'm working. I did verify the read logic against the real `main.jsbundle` from Discord 334.0: the first 8 bytes are the HBC magic `0x1F1903C103BC1FC6`, and bytes `[8..12)` are `96`. That matches the runtime's own `getBytecodeVersion` constant, so the file read and the runtime agree.
